### PR TITLE
Allow setting a custom BD name for a platform

### DIFF
--- a/common/design.master.tcl.template
+++ b/common/design.master.tcl.template
@@ -74,7 +74,7 @@ set_msg_config -suppress -id {[xilinx.com:ip:axi_intc:4.1-7]}
 @@COMPOSITION@@
 
 # create design
-create_bd_design -quiet "system"
+create_bd_design -quiet [platform::get_bd_name]
 
 # enable PE-local memories
 tapasco::add_capabilities_flag "PLATFORM_CAP0_PE_LOCAL_MEM"

--- a/platform/common/platform.tcl
+++ b/platform/common/platform.tcl
@@ -164,6 +164,15 @@ namespace eval platform {
     }
   }
 
+  proc get_bd_name {} {
+    variable bd_design_name
+    if {[info exists bd_design_name] == 0} {
+      return "system"
+    } else {
+      return "${platform::bd_design_name}"
+    }
+  }
+
   # Platform API: Main entry point to generate the bitstream.
   proc generate {} {
     global bitstreamname
@@ -171,7 +180,7 @@ namespace eval platform {
     set jobs [tapasco::get_number_of_processors]
     puts "  using $jobs parallel jobs"
 
-    generate_target all [get_files system.bd]
+    generate_target all [get_files "[get_bd_name].bd"]
     set synth_run [get_runs synth_1]
     set_property -dict [list \
       STEPS.SYNTH_DESIGN.ARGS.RETIMING true \


### PR DESCRIPTION
As per title. Can be used in a platform script like this:

```tcl
namespace eval platform {
  variable bd_design_name
  set bd_design_name "cl"
  # ...
```