### PR TITLE
[Fix Issue #27]

### DIFF
--- a/src/main/scala/tapasco/task/Tasks.scala
+++ b/src/main/scala/tapasco/task/Tasks.scala
@@ -125,6 +125,7 @@ class Tasks(maxParallel: Option[Int] = None) extends Publisher {
   def stop(): Unit = {
     _stop = true
     if (processingThread.isAlive()) processingThread.interrupt()
+    _exectx.shutdown();
   }
   private[this] var _stop = false
 


### PR DESCRIPTION
Insert missing thread pool shutdown routine (exectx.shutdown()). This will work only under the assumption that each executor of _all_ available job types make sure to terminate only after the tasks they spawned will have fully completed. If this is not a sensible assumption, the stop() procedure would have to wait until Tasks::_queued and Tasks::_running is empty (this is sufficient because processingThread will have been terminated by then).