### PR TITLE
Feature/delete dse projects

### DIFF
--- a/src/main/scala/tapasco/Tapasco.scala
+++ b/src/main/scala/tapasco/Tapasco.scala
@@ -123,7 +123,7 @@ object Tapasco {
 
     if (! ok) {
       logger.error("TaPaSCo finished with errors")
-      //sys.exit(1)
+      sys.exit(1)
     } else {
       logger.info("TaPaSCo finished successfully")
     }

--- a/src/main/scala/tapasco/Tapasco.scala
+++ b/src/main/scala/tapasco/Tapasco.scala
@@ -123,7 +123,7 @@ object Tapasco {
 
     if (! ok) {
       logger.error("TaPaSCo finished with errors")
-      sys.exit(1)
+      //sys.exit(1)
     } else {
       logger.info("TaPaSCo finished successfully")
     }

--- a/src/main/scala/tapasco/activity/composers/VivadoComposer.scala
+++ b/src/main/scala/tapasco/activity/composers/VivadoComposer.scala
@@ -111,6 +111,8 @@ class VivadoComposer()(implicit cfg: Configuration) extends Composer {
 
   /** @inheritdoc */
   def clean(bd: Composition, target: Target, f: Double = 0)(implicit cfg: Configuration): Unit = {
+    cfg.outputDir(bd, target, f).resolve("microarch").toFile.deleteOnExit
+    cfg.outputDir(bd, target, f).resolve("user_ip").toFile.deleteOnExit
     Common.getFiles(cfg.outputDir(bd, target, f).resolve("microarch").toFile).filter(_.isFile).map(_.delete)
     Common.getFiles(cfg.outputDir(bd, target, f).resolve("microarch").toFile).filter(_.isDirectory).map(_.deleteOnExit)
     Common.getFiles(cfg.outputDir(bd, target, f).resolve("user_ip").toFile).filter(_.isFile).map(_.delete)

--- a/src/main/scala/tapasco/dse/Exploration.scala
+++ b/src/main/scala/tapasco/dse/Exploration.scala
@@ -51,7 +51,7 @@ private class ConcreteExploration(
     val batchSize: Int = Exploration.MAX_BATCH_SZ,
     val basePath: Path,
     val debugMode: Option[String],
-    val deleteOnFail: Boolean = false)(implicit cfg: Configuration, val tasks: Tasks) extends Exploration {
+    val deleteOnFail: Option[Boolean])(implicit cfg: Configuration, val tasks: Tasks) extends Exploration {
   private implicit val _exploration = this
   private[this] val _logger = de.tu_darmstadt.cs.esa.tapasco.Logging.logger(getClass)
   private var _result: Option[(DesignSpace.Element, Composer.Result)] = None
@@ -234,7 +234,7 @@ object Exploration {
             batchSize: Int = MAX_BATCH_SZ,
             basePath: Path,
             debugMode: Option[String] = None,
-            deleteOnFail: Boolean = false) (implicit cfg: Configuration, tsk: Tasks): Exploration =
+            deleteOnFail: Option[Boolean]) (implicit cfg: Configuration, tsk: Tasks): Exploration =
     new ConcreteExploration(initialComposition, target, dimensions, designFrequency, batchSize, basePath, debugMode, deleteOnFail)
   // scalastyle:on parameter.number
 

--- a/src/main/scala/tapasco/dse/Run.scala
+++ b/src/main/scala/tapasco/dse/Run.scala
@@ -35,7 +35,7 @@ sealed private trait Run extends Startable with Ordered[Run] {
     (that.area.utilization, that.element.h, that.element.frequency)
 }
 
-private class ConcreteRun(val no: Int, val element: DesignSpace.Element, val target: Target, val debugMode: Option[String])
+private class ConcreteRun(val no: Int, val element: DesignSpace.Element, val target: Target, val debugMode: Option[String], val deleteOnFail: Boolean = false)
                          (implicit exploration: Exploration, configuration: Configuration) extends Run {
   private[this] var _result: Option[Composer.Result] = None
   private[this] var _task: Option[ComposeTask] = None
@@ -57,7 +57,7 @@ private class ConcreteRun(val no: Int, val element: DesignSpace.Element, val tar
       logFile         = Some("%s/%s/%s.log".format(exploration.basePath, id, id)),
       debugMode       = debugMode,
       onComplete      = res => stop(signal),
-      deleteOnFail  = true)
+      deleteOnFail    = deleteOnFail)
     _task = Some(t)
     exploration.publish(Exploration.Events.RunStarted(element, t))
     exploration.tasks(t) // start task

--- a/src/main/scala/tapasco/dse/Run.scala
+++ b/src/main/scala/tapasco/dse/Run.scala
@@ -56,7 +56,8 @@ private class ConcreteRun(val no: Int, val element: DesignSpace.Element, val tar
       target          = target,
       logFile         = Some("%s/%s/%s.log".format(exploration.basePath, id, id)),
       debugMode       = debugMode,
-      onComplete      = res => stop(signal))
+      onComplete      = res => stop(signal),
+      deleteOnFinish  = true)
     _task = Some(t)
     exploration.publish(Exploration.Events.RunStarted(element, t))
     exploration.tasks(t) // start task

--- a/src/main/scala/tapasco/dse/Run.scala
+++ b/src/main/scala/tapasco/dse/Run.scala
@@ -57,7 +57,7 @@ private class ConcreteRun(val no: Int, val element: DesignSpace.Element, val tar
       logFile         = Some("%s/%s/%s.log".format(exploration.basePath, id, id)),
       debugMode       = debugMode,
       onComplete      = res => stop(signal),
-      deleteOnFinish  = true)
+      deleteOnFail  = true)
     _task = Some(t)
     exploration.publish(Exploration.Events.RunStarted(element, t))
     exploration.tasks(t) // start task

--- a/src/main/scala/tapasco/dse/Run.scala
+++ b/src/main/scala/tapasco/dse/Run.scala
@@ -35,7 +35,7 @@ sealed private trait Run extends Startable with Ordered[Run] {
     (that.area.utilization, that.element.h, that.element.frequency)
 }
 
-private class ConcreteRun(val no: Int, val element: DesignSpace.Element, val target: Target, val debugMode: Option[String], val deleteOnFail: Boolean = false)
+private class ConcreteRun(val no: Int, val element: DesignSpace.Element, val target: Target, val debugMode: Option[String], val deleteOnFail: Option[Boolean])
                          (implicit exploration: Exploration, configuration: Configuration) extends Run {
   private[this] var _result: Option[Composer.Result] = None
   private[this] var _task: Option[ComposeTask] = None

--- a/src/main/scala/tapasco/jobs/Jobs.scala
+++ b/src/main/scala/tapasco/jobs/Jobs.scala
@@ -67,7 +67,8 @@ final case class ComposeJob(
     private val _architectures: Option[Seq[String]] = None,
     private val _platforms: Option[Seq[String]] = None,
     features: Option[Seq[Feature]] = None,
-    debugMode: Option[String] = None) extends Job("compose") {
+    debugMode: Option[String] = None,
+    deleteProjects: Option[Boolean] = None) extends Job("compose") {
   /** Returns the selected composer tool implementation. */
   lazy val implementation: Composer.Implementation = Composer.Implementation(_implementation)
 
@@ -143,7 +144,8 @@ final case class DesignSpaceExplorationJob(
     private val _architectures: Option[Seq[String]] = None,
     private val _platforms: Option[Seq[String]] = None,
     features: Option[Seq[Feature]] = None,
-    debugMode: Option[String] = None) extends Job("dse") {
+    debugMode: Option[String] = None,
+    deleteProjects: Option[Boolean] = None) extends Job("dse") {
   private final val logger = de.tu_darmstadt.cs.esa.tapasco.Logging.logger(getClass)
   // warn if dimensions are completely empty
   dimensions match {

--- a/src/main/scala/tapasco/jobs/executors/Compose.scala
+++ b/src/main/scala/tapasco/jobs/executors/Compose.scala
@@ -80,7 +80,9 @@ private object Compose extends Executor[ComposeJob] {
           target = t,
           features = job.features,
           debugMode = job.debugMode,
-          onComplete = _ => signal.release())
+          onComplete = _ => signal.release(),
+          deleteOnFail = job.deleteProjects getOrElse(false)
+      )
 
       composeTasks foreach { tsk.apply _ }
 

--- a/src/main/scala/tapasco/jobs/executors/Compose.scala
+++ b/src/main/scala/tapasco/jobs/executors/Compose.scala
@@ -81,7 +81,7 @@ private object Compose extends Executor[ComposeJob] {
           features = job.features,
           debugMode = job.debugMode,
           onComplete = _ => signal.release(),
-          deleteOnFail = job.deleteProjects getOrElse(false)
+          deleteOnFail = job.deleteProjects
       )
 
       composeTasks foreach { tsk.apply _ }

--- a/src/main/scala/tapasco/jobs/executors/DesignSpaceExploration.scala
+++ b/src/main/scala/tapasco/jobs/executors/DesignSpaceExploration.scala
@@ -109,6 +109,7 @@ private object DesignSpaceExploration extends Executor[DesignSpaceExplorationJob
       job.features,
       None, // logfile
       job.debugMode,
-      onComplete
+      onComplete,
+      deleteOnFail = job.deleteProjects getOrElse(false)
     )
 }

--- a/src/main/scala/tapasco/jobs/executors/DesignSpaceExploration.scala
+++ b/src/main/scala/tapasco/jobs/executors/DesignSpaceExploration.scala
@@ -110,6 +110,6 @@ private object DesignSpaceExploration extends Executor[DesignSpaceExplorationJob
       None, // logfile
       job.debugMode,
       onComplete,
-      deleteOnFail = job.deleteProjects getOrElse(false)
+      deleteOnFail = job.deleteProjects getOrElse false
     )
 }

--- a/src/main/scala/tapasco/jobs/executors/DesignSpaceExploration.scala
+++ b/src/main/scala/tapasco/jobs/executors/DesignSpaceExploration.scala
@@ -110,6 +110,6 @@ private object DesignSpaceExploration extends Executor[DesignSpaceExplorationJob
       None, // logfile
       job.debugMode,
       onComplete,
-      deleteOnFail = job.deleteProjects getOrElse false
+      job.deleteProjects
     )
 }

--- a/src/main/scala/tapasco/jobs/json/package.scala
+++ b/src/main/scala/tapasco/jobs/json/package.scala
@@ -146,7 +146,7 @@ package object json {
     (JsPath \ "Platforms").readNullable[Seq[String]] ~
     (JsPath \ "Features").readNullable[Seq[Feature]] ~
     (JsPath \ "DebugMode").readNullable[String] ~
-    (JsPath \ "DeleteÜrpkects").readNullable[Boolean]
+    (JsPath \ "DeleteProjects").readNullable[Boolean]
   ) (DesignSpaceExplorationJob.apply _)
 
   implicit val dseJobWrites: Writes[DesignSpaceExplorationJob] = (

--- a/src/main/scala/tapasco/jobs/json/package.scala
+++ b/src/main/scala/tapasco/jobs/json/package.scala
@@ -116,7 +116,8 @@ package object json {
     (JsPath \ "Architectures").readNullable[Seq[String]] ~
     (JsPath \ "Platforms").readNullable[Seq[String]] ~
     (JsPath \ "Features").readNullable[Seq[Feature]] ~
-    (JsPath \ "DebugMode").readNullable[String]
+    (JsPath \ "DebugMode").readNullable[String] ~
+    (JsPath \ "DeleteProjects").readNullable[Boolean]
   ) (ComposeJob.apply _)
 
   implicit val composeJobWrites: Writes[ComposeJob] = (
@@ -127,7 +128,8 @@ package object json {
     (JsPath \ "Architectures").writeNullable[Seq[String]] ~
     (JsPath \ "Platforms").writeNullable[Seq[String]] ~
     (JsPath \ "Features").writeNullable[Seq[Feature]] ~
-    (JsPath \ "DebugMode").writeNullable[String]
+    (JsPath \ "DebugMode").writeNullable[String] ~
+    (JsPath \ "DeleteProjects").writeNullable[Boolean]
   ) (unlift(ComposeJob.unapply _ andThen (_ map ("Compose" +: _))))
   /* ComposeJob @} */
 
@@ -143,7 +145,8 @@ package object json {
     (JsPath \ "Architectures").readNullable[Seq[String]] ~
     (JsPath \ "Platforms").readNullable[Seq[String]] ~
     (JsPath \ "Features").readNullable[Seq[Feature]] ~
-    (JsPath \ "DebugMode").readNullable[String]
+    (JsPath \ "DebugMode").readNullable[String] ~
+    (JsPath \ "DeleteÜrpkects").readNullable[Boolean]
   ) (DesignSpaceExplorationJob.apply _)
 
   implicit val dseJobWrites: Writes[DesignSpaceExplorationJob] = (
@@ -157,7 +160,8 @@ package object json {
     (JsPath \ "Architectures").writeNullable[Seq[String]] ~
     (JsPath \ "Platforms").writeNullable[Seq[String]] ~
     (JsPath \ "Features").writeNullable[Seq[Feature]] ~
-    (JsPath \ "DebugMode").writeNullable[String]
+    (JsPath \ "DebugMode").writeNullable[String] ~
+    (JsPath \ "DeleteProjects").writeNullable[Boolean]
   ) (unlift(DesignSpaceExplorationJob.unapply _ andThen (_ map ("DesignSpaceExploration" +: _))))
   /* DesignSpaceExplorationJob @} */
 

--- a/src/main/scala/tapasco/parser/BasicParsers.scala
+++ b/src/main/scala/tapasco/parser/BasicParsers.scala
@@ -84,6 +84,9 @@ private object BasicParsers {
   val dblstr: Parser[String] =
     (signednumstr.! ~ (CharIn(",.") ~ numstr).!.?) map { case (n, r) => n ++ r.getOrElse("")  }
 
+  val boolstr: Parser[Boolean] =
+    ("true" | "false" ).! map { _.toBoolean} opaque "boolean"
+
   val double: Parser[Double] = dblstr.map(_.toDouble)
       .opaque("floating point number")
 

--- a/src/main/scala/tapasco/parser/CommonArgParsers.scala
+++ b/src/main/scala/tapasco/parser/CommonArgParsers.scala
@@ -67,6 +67,9 @@ private object CommonArgParsers {
     longOption("debugMode", "DebugMode") ~ ws ~/
     qstring.opaque("debug mode name, any string") ~ ws
 
+  def delProj: Parser[(String, Boolean)] =
+    (longOption("deleteProjects", "DeleteProjects") ~ ws) map {case s => (s, true)}
+
   def implementation: Parser[(String, String)] =
     longOption("implementation", "Implementation") ~
     ws ~/

--- a/src/main/scala/tapasco/parser/CommonArgParsers.scala
+++ b/src/main/scala/tapasco/parser/CommonArgParsers.scala
@@ -17,11 +17,13 @@
 // along with Tapasco.  If not, see <http://www.gnu.org/licenses/>.
 //
 package de.tu_darmstadt.cs.esa.tapasco.parser
-import  de.tu_darmstadt.cs.esa.tapasco.base._
-import  de.tu_darmstadt.cs.esa.tapasco.base.json._
-import  de.tu_darmstadt.cs.esa.tapasco.dse.Heuristics
-import  fastparse.all._
-import  java.nio.file._
+import de.tu_darmstadt.cs.esa.tapasco.base._
+import de.tu_darmstadt.cs.esa.tapasco.base.json._
+import de.tu_darmstadt.cs.esa.tapasco.dse.Heuristics
+import fastparse.all._
+import java.nio.file._
+
+import scala.util.Try
 
 private object CommonArgParsers {
   import BasicParsers._
@@ -68,7 +70,8 @@ private object CommonArgParsers {
     qstring.opaque("debug mode name, any string") ~ ws
 
   def delProj: Parser[(String, Boolean)] =
-    (longOption("deleteProjects", "DeleteProjects") ~ ws) map {case s => (s, true)}
+    (longOption("deleteProjects", "DeleteProjects") ~ ws ~/
+      ( boolstr ~ ws).?) map {case s => (s._1, s._2.getOrElse(true))}
 
   def implementation: Parser[(String, String)] =
     longOption("implementation", "Implementation") ~

--- a/src/main/scala/tapasco/parser/ComposeParser.scala
+++ b/src/main/scala/tapasco/parser/ComposeParser.scala
@@ -39,7 +39,7 @@ private object ComposeParser {
   private val jobid = identity[ComposeJob] _
 
   private def options: Parser[ComposeJob => ComposeJob] =
-    (implementation | architectures | platforms | features | debugMode).rep
+    (implementation | architectures | platforms | features | debugMode | delProj).rep
       .map (opts => (opts map (applyOption _) fold jobid) (_ andThen _))
 
   private def applyOption(opt: (String, _)): ComposeJob => ComposeJob =
@@ -49,6 +49,7 @@ private object ComposeParser {
       case ("Platforms", ps: Seq[String @unchecked]) => _.copy(_platforms = Some(ps))
       case ("Features", fs: Seq[Feature @unchecked]) => _.copy(features = Some(fs))
       case ("DebugMode", m: String) => _.copy(debugMode = Some(m))
+      case ("DeleteProjects", e: Boolean) => _.copy(deleteProjects = Some(e))
       case o => throw new Exception(s"parsed illegal option: $o")
     }
 }

--- a/src/main/scala/tapasco/parser/DesignSpaceExploration.scala
+++ b/src/main/scala/tapasco/parser/DesignSpaceExploration.scala
@@ -41,7 +41,7 @@ private object DesignSpaceExplorationParser {
     ))}
 
   private def optionsMap: Parser[Seq[(String, _)]] =
-    (heuristic | batchSize | basePath | architectures | platforms | features | debugMode).rep
+    (heuristic | batchSize | basePath | architectures | platforms | features | debugMode | delProj).rep
 
   private val jobid = identity[DesignSpaceExplorationJob] _
 
@@ -66,6 +66,7 @@ private object DesignSpaceExplorationParser {
       case ("BasePath", p: Path) => _.copy(basePath = Some(p))
       case ("Features", fs: Seq[Feature @unchecked]) => _.copy(features = Some(fs))
       case ("DebugMode", m: String) => _.copy(debugMode = Some(m))
+      case ("DeleteProjects", e: Boolean) => _.copy(deleteProjects = Some(e))
       case o => throw new Exception(s"parsed illegal option: $o")
     }
 

--- a/src/main/scala/tapasco/parser/Usage.scala
+++ b/src/main/scala/tapasco/parser/Usage.scala
@@ -163,7 +163,7 @@ configuration via `tapasco -n config.json`.
                                         """default: "Vivado"""") &
            Arg("--features FEATURES", "configures Features, see `tapasco -h features`" &
                                       "syntax: FEATURE [, FEATURE]*") &
-           Arg("--deleteProjects", "delete all generated Project-Files") &
+           Arg("--deleteProjects (true | false)?", "Spefify whether project files are deleted or kept") &
            Arg("--debugMode NAME", "dry run, no composition is executed; modes:") &
            Indent(Arg("  r", "generate random result values") &
                   Arg("  f", "generate only timing failures") &
@@ -318,7 +318,7 @@ configuration via `tapasco -n config.json`.
                                   "default: number of CPUs") &
            Arg("--debugMode NAME", "dry run, no compositions are executed, see" ~
                                    "`tapasco -h compose`") &
-           Arg("--deleteProjects", "Delete all generated Project-Files") &
+           Arg("--deleteProjects ( true | false )?", "Spefify whether project files are deleted or kept") &
            Arg("--features FEATURES", "configures Features, see `tapasco -h features`" &
                                       "syntax: FEATURE [, FEATURE]*") &
            Arg("--heuristic NAME", "select heuristic function" &

--- a/src/main/scala/tapasco/parser/Usage.scala
+++ b/src/main/scala/tapasco/parser/Usage.scala
@@ -163,7 +163,8 @@ configuration via `tapasco -n config.json`.
                                         """default: "Vivado"""") &
            Arg("--features FEATURES", "configures Features, see `tapasco -h features`" &
                                       "syntax: FEATURE [, FEATURE]*") &
-           Arg("--deleteProjects (true | false)?", "Spefify whether project files are deleted or kept") &
+           Arg("--deleteProjects (true | false)?", "Spefify whether project files are deleted or kept" &
+                                                   """default: true""") &
            Arg("--debugMode NAME", "dry run, no composition is executed; modes:") &
            Indent(Arg("  r", "generate random result values") &
                   Arg("  f", "generate only timing failures") &
@@ -318,7 +319,8 @@ configuration via `tapasco -n config.json`.
                                   "default: number of CPUs") &
            Arg("--debugMode NAME", "dry run, no compositions are executed, see" ~
                                    "`tapasco -h compose`") &
-           Arg("--deleteProjects ( true | false )?", "Spefify whether project files are deleted or kept") &
+           Arg("--deleteProjects ( true | false )?", "Spefify whether project files are deleted or kept" &
+                                                     """default: true""" ) &
            Arg("--features FEATURES", "configures Features, see `tapasco -h features`" &
                                       "syntax: FEATURE [, FEATURE]*") &
            Arg("--heuristic NAME", "select heuristic function" &

--- a/src/main/scala/tapasco/parser/Usage.scala
+++ b/src/main/scala/tapasco/parser/Usage.scala
@@ -163,6 +163,7 @@ configuration via `tapasco -n config.json`.
                                         """default: "Vivado"""") &
            Arg("--features FEATURES", "configures Features, see `tapasco -h features`" &
                                       "syntax: FEATURE [, FEATURE]*") &
+           Arg("--deleteProjects", "delete all generated Project-Files") &
            Arg("--debugMode NAME", "dry run, no composition is executed; modes:") &
            Indent(Arg("  r", "generate random result values") &
                   Arg("  f", "generate only timing failures") &
@@ -317,6 +318,7 @@ configuration via `tapasco -n config.json`.
                                   "default: number of CPUs") &
            Arg("--debugMode NAME", "dry run, no compositions are executed, see" ~
                                    "`tapasco -h compose`") &
+           Arg("--deleteProjects", "Delete all generated Project-Files") &
            Arg("--features FEATURES", "configures Features, see `tapasco -h features`" &
                                       "syntax: FEATURE [, FEATURE]*") &
            Arg("--heuristic NAME", "select heuristic function" &

--- a/src/main/scala/tapasco/task/ComposeTask.scala
+++ b/src/main/scala/tapasco/task/ComposeTask.scala
@@ -41,7 +41,8 @@ class ComposeTask(composition: Composition,
                   features: Option[Seq[Feature]] = None,
                   logFile: Option[String] = None,
                   debugMode: Option[String] = None,
-                  val onComplete: Boolean => Unit)
+                  val onComplete: Boolean => Unit,
+                  val deleteOnFinish: Boolean = false)
                  (implicit cfg: Configuration) extends Task with LogTracking {
   private[this] implicit val _logger = de.tu_darmstadt.cs.esa.tapasco.Logging.logger(getClass)
   private[this] val _slurm = Slurm.enabled
@@ -88,7 +89,7 @@ class ComposeTask(composition: Composition,
 
     LogFileTracker.stopLogFileAppender(appender)
     val result = (_composerResult map (_.result) getOrElse false) == ComposeResult.Success
-    if (result) { composer.clean(composition, target, designFrequency) }
+    if (result || deleteOnFinish) { composer.clean(composition, target, designFrequency) } // TODO This has to be run, if this compose task is part of a DSE
     result
   }
 

--- a/src/main/scala/tapasco/task/ComposeTask.scala
+++ b/src/main/scala/tapasco/task/ComposeTask.scala
@@ -42,7 +42,7 @@ class ComposeTask(composition: Composition,
                   logFile: Option[String] = None,
                   debugMode: Option[String] = None,
                   val onComplete: Boolean => Unit,
-                  val deleteOnFail: Boolean = false)
+                  val deleteOnFail: Option[Boolean] = None)
                  (implicit cfg: Configuration) extends Task with LogTracking {
   private[this] implicit val _logger = de.tu_darmstadt.cs.esa.tapasco.Logging.logger(getClass)
   private[this] val _slurm = Slurm.enabled
@@ -90,7 +90,9 @@ class ComposeTask(composition: Composition,
 
     LogFileTracker.stopLogFileAppender(appender)
     val result = (_composerResult map (_.result) getOrElse false) == ComposeResult.Success
-    if (result || deleteOnFail) { composer.clean(composition, target, designFrequency) } // TODO This has to be run, if this compose task is part of a DSE
+    // If --deleteProjects is set use the corresponding value, else delete only successful runs
+    val delete = if(deleteOnFail.isDefined) deleteOnFail.get else result
+    if (delete) { composer.clean(composition, target, designFrequency) }
     result
   }
 

--- a/src/main/scala/tapasco/task/ComposeTask.scala
+++ b/src/main/scala/tapasco/task/ComposeTask.scala
@@ -59,7 +59,6 @@ class ComposeTask(composition: Composition,
   def job: Boolean = if (! _slurm) nodeExecution else slurmExecution
 
   private def nodeExecution: Boolean = {
-
     val appender = LogFileTracker.setupLogFileAppender(_logFile.toString)
     val composer = Composer(implementation)(cfg)
     _logger.debug("launching compose run for {}@{} [current thread: {}], logfile {}",

--- a/src/main/scala/tapasco/task/ComposeTask.scala
+++ b/src/main/scala/tapasco/task/ComposeTask.scala
@@ -42,7 +42,7 @@ class ComposeTask(composition: Composition,
                   logFile: Option[String] = None,
                   debugMode: Option[String] = None,
                   val onComplete: Boolean => Unit,
-                  val deleteOnFinish: Boolean = false)
+                  val deleteOnFail: Boolean = false)
                  (implicit cfg: Configuration) extends Task with LogTracking {
   private[this] implicit val _logger = de.tu_darmstadt.cs.esa.tapasco.Logging.logger(getClass)
   private[this] val _slurm = Slurm.enabled
@@ -59,6 +59,7 @@ class ComposeTask(composition: Composition,
   def job: Boolean = if (! _slurm) nodeExecution else slurmExecution
 
   private def nodeExecution: Boolean = {
+
     val appender = LogFileTracker.setupLogFileAppender(_logFile.toString)
     val composer = Composer(implementation)(cfg)
     _logger.debug("launching compose run for {}@{} [current thread: {}], logfile {}",
@@ -89,7 +90,7 @@ class ComposeTask(composition: Composition,
 
     LogFileTracker.stopLogFileAppender(appender)
     val result = (_composerResult map (_.result) getOrElse false) == ComposeResult.Success
-    if (result || deleteOnFinish) { composer.clean(composition, target, designFrequency) } // TODO This has to be run, if this compose task is part of a DSE
+    if (result || deleteOnFail) { composer.clean(composition, target, designFrequency) } // TODO This has to be run, if this compose task is part of a DSE
     result
   }
 

--- a/src/main/scala/tapasco/task/DesignSpaceExplorationTask.scala
+++ b/src/main/scala/tapasco/task/DesignSpaceExplorationTask.scala
@@ -50,7 +50,8 @@ private class DesignSpaceExplorationTask(
     features: Option[Seq[Feature]],
     logFile: Option[String],
     debugMode: Option[String],
-    val onComplete: Boolean => Unit)
+    val onComplete: Boolean => Unit,
+    val deleteOnFail: Boolean = false)
     (implicit cfg: Configuration, tsk: Tasks) extends Task with LogTracking with ExplorationTask {
   private[this] val _logger = de.tu_darmstadt.cs.esa.tapasco.Logging.logger(getClass)
   /** Internal representation of result. **/
@@ -167,7 +168,8 @@ object DesignSpaceExplorationTask {
             features: Option[Seq[Feature]],
             logFile: Option[String],
             debugMode: Option[String],
-            onComplete: Boolean => Unit)
+            onComplete: Boolean => Unit,
+            deleteOnFail: Boolean = false)
            (implicit cfg: Configuration, tsk: Tasks): ExplorationTask = {
     new DesignSpaceExplorationTask(
         composition,
@@ -180,7 +182,8 @@ object DesignSpaceExplorationTask {
         features,
         logFile,
         debugMode,
-        onComplete)
+        onComplete,
+        deleteOnFail)
   }
   // scalastyle:on parameter.number
 }

--- a/src/main/scala/tapasco/task/DesignSpaceExplorationTask.scala
+++ b/src/main/scala/tapasco/task/DesignSpaceExplorationTask.scala
@@ -75,7 +75,8 @@ private class DesignSpaceExplorationTask(
     designFrequency,
     batchSize,
     _bp,
-    debugMode
+    debugMode,
+    deleteOnFail
   )(_cfg, tsk)
 
   /**

--- a/src/main/scala/tapasco/task/DesignSpaceExplorationTask.scala
+++ b/src/main/scala/tapasco/task/DesignSpaceExplorationTask.scala
@@ -51,7 +51,7 @@ private class DesignSpaceExplorationTask(
     logFile: Option[String],
     debugMode: Option[String],
     val onComplete: Boolean => Unit,
-    val deleteOnFail: Boolean = false)
+    val deleteOnFail: Option[Boolean])
     (implicit cfg: Configuration, tsk: Tasks) extends Task with LogTracking with ExplorationTask {
   private[this] val _logger = de.tu_darmstadt.cs.esa.tapasco.Logging.logger(getClass)
   /** Internal representation of result. **/
@@ -170,7 +170,7 @@ object DesignSpaceExplorationTask {
             logFile: Option[String],
             debugMode: Option[String],
             onComplete: Boolean => Unit,
-            deleteOnFail: Boolean = false)
+            deleteOnFail: Option[Boolean])
            (implicit cfg: Configuration, tsk: Tasks): ExplorationTask = {
     new DesignSpaceExplorationTask(
         composition,

--- a/src/test/scala/tapasco/parser/CommonArgParsersSpec.scala
+++ b/src/test/scala/tapasco/parser/CommonArgParsersSpec.scala
@@ -108,7 +108,9 @@ private object CommonArgParsersSpec {
     qstringGen
   ))
 
-  val deleteProjectsGen: Gen[String] = join(Seq(genLongOption("deleteProjects")))
+  val booleanOrNoneGen: Gen[String] = Gen.oneOf("true", "false", "")
+
+  val deleteProjectsGen: Gen[String] = join(Seq(genLongOption("deleteProjects"), booleanOrNoneGen))
 
   val implementationGen: Gen[String] = join(Seq(
     genLongOption("implementation"),

--- a/src/test/scala/tapasco/parser/CommonArgParsersSpec.scala
+++ b/src/test/scala/tapasco/parser/CommonArgParsersSpec.scala
@@ -57,6 +57,11 @@ class CommonArgParsersSpec extends FlatSpec with Matchers with Checkers {
       checkParsed( P( debugMode ~ End ).parse(d) )
     })
 
+  "The deleteProject switch" should "be parsed correctly by deleteProject" in
+    check(forAllNoShrink(deleteProjectsGen) { d =>
+      checkParsed( P( delProj ~ End).parse(d) )
+    })
+
   "All valid implementation parameters" should "be parsed correctly by implementation" in
     check(forAllNoShrink(implementationGen) { i =>
       checkParsed( P( implementation ~ End ).parse(i) )
@@ -102,6 +107,8 @@ private object CommonArgParsersSpec {
     genLongOption("debugMode"),
     qstringGen
   ))
+
+  val deleteProjectsGen: Gen[String] = join(Seq(genLongOption("deleteProjects")))
 
   val implementationGen: Gen[String] = join(Seq(
     genLongOption("implementation"),

--- a/src/test/scala/tapasco/parser/ComposeParserSpec.scala
+++ b/src/test/scala/tapasco/parser/ComposeParserSpec.scala
@@ -40,7 +40,8 @@ private object ComposeParserSpec {
     CommonArgParsersSpec.architecturesGen,
     CommonArgParsersSpec.platformsGen,
     FeatureParsersSpec.featuresGen,
-    CommonArgParsersSpec.debugModeGen
+    CommonArgParsersSpec.debugModeGen,
+    CommonArgParsersSpec.deleteProjectsGen
   )
   val optionsGen: Gen[String] = for {
     n <- Gen.choose(1, 20)

--- a/src/test/scala/tapasco/parser/DesignSpaceExplorationParserSpec.scala
+++ b/src/test/scala/tapasco/parser/DesignSpaceExplorationParserSpec.scala
@@ -71,7 +71,9 @@ private object DesignSpaceExplorationParserSpec {
     batchSizeGen,
     basePath,
     architecturesGen,
-    platformsGen
+    platformsGen,
+    debugModeGen,
+    deleteProjectsGen
   )
 
   val optionsGen: Gen[String] = for {


### PR DESCRIPTION
Using the newly introduced CL-Option `--deleteProjects`, Project Files can now be deleted after compose or explore runs.
The option also allows overriding to keep projects using these variants:
`--deleteProjects true` -> delete all Project Files
`--deleteProjects false` -> keep all Project Files
`--deleteProjects` -> delete all Project files (equal to `--deleteProjects true`)