### PR TITLE
Apply memory workaround for AU250 only for affected Vivado versions

### DIFF
--- a/platform/AU250/AU250.tcl
+++ b/platform/AU250/AU250.tcl
@@ -41,11 +41,14 @@ namespace eval platform {
     apply_board_connection -board_interface "default_300mhz_clk0" -ip_intf "$name/C0_SYS_CLK" -diagram "system"
     apply_bd_automation -rule xilinx.com:bd_rule:board -config {Board_Interface "resetn ( FPGA Resetn ) " }  [get_bd_pins $name/sys_rst]
 
-    delete_bd_objs [get_bd_nets resetn_1]
-    set rst_inv [tapasco::ip::create_logic_vector "rst_inv_ddr_in"]
-    set_property -dict [list CONFIG.C_SIZE {1} CONFIG.C_OPERATION {not} CONFIG.LOGO_FILE {data/sym_notgate.png}] $rst_inv
-    connect_bd_net [get_bd_pins $rst_inv/Res] [get_bd_pins $name/sys_rst]
-    connect_bd_net [get_bd_pins resetn] [get_bd_pins $rst_inv/Op1]
+    # Vivado 2018.3 requires invert of reset signal
+    if { [::tapasco::vivado_is_newer "2019.1"] == 0} {
+      delete_bd_objs [get_bd_nets resetn_1]
+      set rst_inv [tapasco::ip::create_logic_vector "rst_inv_ddr_in"]
+      set_property -dict [list CONFIG.C_SIZE {1} CONFIG.C_OPERATION {not} CONFIG.LOGO_FILE {data/sym_notgate.png}] $rst_inv
+      connect_bd_net [get_bd_pins $rst_inv/Res] [get_bd_pins $name/sys_rst]
+      connect_bd_net [get_bd_pins resetn] [get_bd_pins $rst_inv/Op1]
+    }
 
     connect_bd_intf_net [get_bd_intf_pins ${name}/C0_DDR4_S_AXI_CTRL] $s_axi_host
 


### PR DESCRIPTION
The MIG for AU250 does not require the manual workaround in Vivado 2019.1. 