### PR TITLE
Replaced deprecated method in DirectoryWatcher

### DIFF
--- a/toolflow/scala/src/main/scala/tapasco/filemgmt/DirectoryWatcher.scala
+++ b/toolflow/scala/src/main/scala/tapasco/filemgmt/DirectoryWatcher.scala
@@ -163,7 +163,7 @@ private class DefaultDirectoryWatcher(val paths: Set[Path]) extends DirectoryWat
     * Waits for WatchService events in blocking mode, publishes corresponding events.
     **/
   private def startWatchThread(): Boolean = {
-    val started = _watchThread.weakCompareAndSet(None, {
+    val started = _watchThread.compareAndSet(None, {
       _logger.trace("starting watchkey thread for {} ...", paths)
       Some(new Thread(new WatchThread))
     })


### PR DESCRIPTION
I've replaced the deprecated method `weakCompareAndSet` (#84) in the `DirectoryWatcher`. 

To remain compatible with Java version 8, I've used `compareAndSet` instead of the proposed replacement `weakCompareAndSetPlain`, because the latter is not available in Java 8.