### PR TITLE
Consider maximum number of tasks for default batch size. 

### DIFF
--- a/toolflow/scala/src/main/scala/tapasco/filemgmt/FileAssetManager.scala
+++ b/toolflow/scala/src/main/scala/tapasco/filemgmt/FileAssetManager.scala
@@ -70,6 +70,15 @@ final object FileAssetManager extends Publisher {
       _logger.error("FATAL: TAPASCO_HOME environment variable is not set")
       throw e
   }
+
+  lazy val TAPASCO_WORK_DIR = try {
+    Paths.get(sys.env("TAPASCO_WORK_DIR")).toAbsolutePath().normalize
+  }
+  catch {
+    case e: NoSuchElementException =>
+      _logger.error("FATAL: TAPASCO_WORK_DIR environment variable is not set")
+      throw e
+  }
   /* @} */
 
   def apply(cfg: Configuration): Unit = {

--- a/toolflow/scala/src/main/scala/tapasco/jobs/JobExamples.scala
+++ b/toolflow/scala/src/main/scala/tapasco/jobs/JobExamples.scala
@@ -51,7 +51,7 @@ object JobExamples {
     123.0,
     DesignSpace.Dimensions(true, true, false),
     Heuristics.ThroughputHeuristic,
-    16,
+    Some(16),
     Some(Paths.get("nonstandard/base/path")),
     Some(Seq("axi4mm")),
     Some(Seq("pynq", "vc709")),

--- a/toolflow/scala/src/main/scala/tapasco/jobs/Jobs.scala
+++ b/toolflow/scala/src/main/scala/tapasco/jobs/Jobs.scala
@@ -148,7 +148,7 @@ final case class DesignSpaceExplorationJob(
                                             initialFrequency: Heuristics.Frequency,
                                             dimensions: DesignSpace.Dimensions,
                                             heuristic: Heuristics.Heuristic,
-                                            batchSize: Int,
+                                            batchSize: Option[Int],
                                             basePath: Option[Path] = None,
                                             private val _architectures: Option[Seq[String]] = None,
                                             private val _platforms: Option[Seq[String]] = None,

--- a/toolflow/scala/src/main/scala/tapasco/jobs/executors/DesignSpaceExploration.scala
+++ b/toolflow/scala/src/main/scala/tapasco/jobs/executors/DesignSpaceExploration.scala
@@ -108,7 +108,7 @@ private object DesignSpaceExploration extends Executor[DesignSpaceExplorationJob
       job.dimensions,
       job.initialFrequency,
       job.heuristic,
-      job.batchSize,
+      job.batchSize.getOrElse(cfg.maxTasks.getOrElse(Runtime.getRuntime.availableProcessors())-1),
       job.basePath map (_.toString),
       job.features,
       None, // logfile

--- a/toolflow/scala/src/main/scala/tapasco/jobs/json/package.scala
+++ b/toolflow/scala/src/main/scala/tapasco/jobs/json/package.scala
@@ -144,7 +144,7 @@ package object json {
       (JsPath \ "Initial Frequency").readNullable[Heuristics.Frequency].map(_ getOrElse 100.0) ~
       (JsPath \ "Dimensions").read[DesignSpace.Dimensions] ~
       (JsPath \ "Heuristic").read[Heuristics.Heuristic] ~
-      (JsPath \ "Batch Size").read[Int](verifying[Int](_ > 0)) ~
+      (JsPath \ "Batch Size").readNullable[Int](verifying[Int](_ > 0)) ~
       (JsPath \ "Output Path").readNullable[Path] ~
       (JsPath \ "Architectures").readNullable[Seq[String]] ~
       (JsPath \ "Platforms").readNullable[Seq[String]] ~
@@ -159,7 +159,7 @@ package object json {
       (JsPath \ "Initial Frequency").write[Heuristics.Frequency] ~
       (JsPath \ "Dimensions").write[DesignSpace.Dimensions] ~
       (JsPath \ "Heuristic").write[Heuristics.Heuristic] ~
-      (JsPath \ "Batch Size").write[Int] ~
+      (JsPath \ "Batch Size").writeNullable[Int] ~
       (JsPath \ "Output Path").writeNullable[Path] ~
       (JsPath \ "Architectures").writeNullable[Seq[String]] ~
       (JsPath \ "Platforms").writeNullable[Seq[String]] ~

--- a/toolflow/scala/src/main/scala/tapasco/parser/DesignSpaceExploration.scala
+++ b/toolflow/scala/src/main/scala/tapasco/parser/DesignSpaceExploration.scala
@@ -40,7 +40,7 @@ private object DesignSpaceExplorationParser {
     initialFrequency = optfreq getOrElse 100.0,
     dimensions = dims,
     heuristic = Heuristics.ThroughputHeuristic,
-    batchSize = Runtime.getRuntime().availableProcessors()
+    batchSize = None
   ))
   }
 
@@ -66,7 +66,7 @@ private object DesignSpaceExplorationParser {
       case ("Architectures", as: Seq[String@unchecked]) => _.copy(_architectures = Some(as))
       case ("Platforms", as: Seq[String@unchecked]) => _.copy(_platforms = Some(as))
       case ("Heuristic", h: String) => _.copy(heuristic = Heuristics(h))
-      case ("BatchSize", i: Int) => _.copy(batchSize = i)
+      case ("BatchSize", i: Int) => _.copy(batchSize = Some(i))
       case ("BasePath", p: Path) => _.copy(basePath = Some(p))
       case ("Features", fs: Seq[Feature@unchecked]) => _.copy(features = Some(fs))
       case ("DebugMode", m: String) => _.copy(debugMode = Some(m))

--- a/toolflow/scala/src/main/scala/tapasco/task/DesignSpaceExplorationTask.scala
+++ b/toolflow/scala/src/main/scala/tapasco/task/DesignSpaceExplorationTask.scala
@@ -59,7 +59,7 @@ private class DesignSpaceExplorationTask(
   private[this] var _result: Option[(DesignSpace.Element, Composer.Result)] = None
   private[this] val _bp = basePath map (p => Paths.get(p).toAbsolutePath) getOrElse {
     val shortDate = java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(java.time.LocalDateTime.now())
-    val dsepath = FileAssetManager.TAPASCO_HOME.resolve(
+    val dsepath = FileAssetManager.TAPASCO_WORK_DIR.resolve(
       "DSE_%s".format(shortDate).replace(" ", "_").replace("/", "-").replace(":", "-")
     ).normalize()
     java.nio.file.Files.createDirectories(dsepath.resolve("bd"))


### PR DESCRIPTION
The DSE in TaPaSCo is separated into batches, pruning of the design-space only happens after a batch has completed. 
The batch size can be given via a CLI flag, but if it is not given, the batch size defaults to the number of processors in the system. But if a maximum number of tasks is given, this might not be the desired behavior (see #92).

Therefore the default behavior was changed as follows:
* If the batchSize-flag is given, the given value will be used for the DSE batch size
* In case batchSize is not given, but maxTasks is given, the batch size will be the given maximum number of tasks minus one.
* In case neither of the two flags is given, the batch size will be the number of processors in the system minus one.

Additionally, I changed the default directory for DSE output. The folder for a DSE will now be created as a subdirectory of `TAPASCO_WORK_DIR` instead of `TAPASCO_HOME`.