### PR TITLE
Correctly detect timing errors

### DIFF
--- a/toolflow/scala/src/main/scala/tapasco/activity/composers/VivadoComposer.scala
+++ b/toolflow/scala/src/main/scala/tapasco/activity/composers/VivadoComposer.scala
@@ -99,10 +99,16 @@ class VivadoComposer()(implicit cfg: Configuration) extends Composer {
       logger.error("Vivado timeout for %s in '%s'".format(files.runName, files.outdir))
       Composer.Result(Timeout, log = files.log, util = None, timing = None)
     } else if (r != 0) {
-      logger.error("Vivado finished with non-zero exit code: %d for %s in '%s'"
-        .format(r, files.runName, files.outdir))
-      Composer.Result(files.log map (_.result) getOrElse OtherError, log = files.log,
-        util = None, timing = None)
+      if(files.tim.isDefined){
+        Composer.Result(checkTimingFailure(files), Some(files.bitFile.toString),
+          files.log, files.util, files.tim)
+      }
+      else{
+        logger.error("Vivado finished with non-zero exit code: %d for %s in '%s'"
+          .format(r, files.runName, files.outdir))
+        Composer.Result(files.log map (_.result) getOrElse OtherError, log = files.log,
+          util = None, timing = None)
+      }
     } else {
       // check for timing failure
       if (files.tim.isEmpty) {

--- a/toolflow/scala/src/main/scala/tapasco/parser/Usage.scala
+++ b/toolflow/scala/src/main/scala/tapasco/parser/Usage.scala
@@ -302,9 +302,7 @@ configuration via `tapasco -n config.json`.
         Block(I("Timing failures") ~ "affect only the given element, but generate a feedback" ~
           "element: A new design space element is generated for the same" ~
           "Composition, but with a lower target frequency. The frequency is" ~
-          "computed from the 'worst negative slack' reported by the composer tools." ~
-          "I.e., a failed Composition with 100 MHz target frequency and 0.9ns WNS" ~
-          "would give a new element with 97.74 MHz (T=10.9ns) frequency.") &
+          "reduced by 5 MHz for the next run.") &
         "" &
         Block(I("Other errors:") ~ "This encompasses all other errors, e.g., missing licenses," ~
           "system crashes, out-of-memory problems, etc.")) &


### PR DESCRIPTION
This change affects two things:
* Timing failures are now also detected if Vivado gave a non-zero exit code. This is necessary, because Vivado gives an exit code `1` in some cases, even if only a timing error occured (see #101).
* The help now correctly documents the behavior of the TaPaSCo DSE in case of timing failures (see the discussion of #101).
