### PR TITLE
Feature/java 8 ci fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -425,7 +425,7 @@ tapasco_hls:
     - which vivado_hls
     - curl -s "https://get.sdkman.io" | bash
     - source "/root/.sdkman/bin/sdkman-init.sh"
-    - sdk install java
+    - sdk install java 11.0.4-zulu
     - source $XILINX_VIVADO/settings64.sh
     - source setup.sh
     - pushd ${TAPASCO_HOME_TOOLFLOW}/scala
@@ -454,7 +454,7 @@ tapasco_hls:
     - which vivado_hls
     - curl -s "https://get.sdkman.io" | bash
     - source "/root/.sdkman/bin/sdkman-init.sh"
-    - sdk install java
+    - sdk install java 11.0.4-zulu
     - source $XILINX_VIVADO/settings64.sh
     - source setup.sh
     - pushd ${TAPASCO_HOME_TOOLFLOW}/scala

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ stages:
   stage: test_scala_toolflow
   retry: 2
   variables:
-    JAVA_VERSION: "8.0.212-zulu"
+    JAVA_VERSION: "8.0.222-zulu"
   image: ubuntu:latest
   tags:
     - High
@@ -30,7 +30,7 @@ stages:
 
 test_tapasco_java_8:
   variables:
-    JAVA_VERSION: "8.0.212-zulu"
+    JAVA_VERSION: "8.0.222-zulu"
   extends: .test_tapasco
 
 test_tapasco_java_9:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,7 +56,7 @@ test_tapasco_java_11:
   script:
     - curl -s "https://get.sdkman.io" | bash
     - source "/root/.sdkman/bin/sdkman-init.sh"
-    - sdk install java
+    - sdk install java 11.0.4-zulu
     - source setup.sh
     - cd ${TAPASCO_HOME_TOOLFLOW}/scala
     - ./gradlew installDist


### PR DESCRIPTION
Apparently sdkman is currently broken:
The standard Java version is set to 11.0.3-zulu which is currently not available via sdkman.
To circumvent this problem the java version is now set to the available 11.0.4-zulu instead.

In addition, 8.0.212-zulu is no longer available via sdkman thus it is now upgraded to 8.0.222-zulu.

Consider Pipeline 1462 (https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/pipelines/1462) before merging.