### PR TITLE
Fixes free after use of device memory

### DIFF
--- a/runtime/arch/common/include/tapasco_memory.h
+++ b/runtime/arch/common/include/tapasco_memory.h
@@ -45,7 +45,7 @@ tapasco_res_t tapasco_device_alloc(tapasco_devctx_t *dev_ctx,
  * @param handle memory chunk handle returned by @see tapasco_alloc
  * @param flags device memory allocation flags
  **/
-void tapasco_device_free(tapasco_devctx_t *dev_ctx, tapasco_handle_t handle,
+void tapasco_device_free(tapasco_devctx_t *dev_ctx, tapasco_handle_t handle, size_t len,
                          tapasco_device_alloc_flag_t const flags, ...);
 
 /**

--- a/runtime/arch/common/include/tapasco_memory.h
+++ b/runtime/arch/common/include/tapasco_memory.h
@@ -45,8 +45,9 @@ tapasco_res_t tapasco_device_alloc(tapasco_devctx_t *dev_ctx,
  * @param handle memory chunk handle returned by @see tapasco_alloc
  * @param flags device memory allocation flags
  **/
-void tapasco_device_free(tapasco_devctx_t *dev_ctx, tapasco_handle_t handle, size_t len,
-                         tapasco_device_alloc_flag_t const flags, ...);
+void tapasco_device_free(tapasco_devctx_t *dev_ctx, tapasco_handle_t handle,
+                         size_t len, tapasco_device_alloc_flag_t const flags,
+                         ...);
 
 /**
  * Copys memory from main memory to the FPGA device.

--- a/runtime/arch/common/src/tapasco_delayed_transfers.c
+++ b/runtime/arch/common/src/tapasco_delayed_transfers.c
@@ -73,7 +73,7 @@ tapasco_res_t tapasco_transfer_from(tapasco_devctx_t *devctx,
   }
   LOG(LALL_TRANSFERS, "job %lu: freeing buffer with length %zd bytes",
       (unsigned long)j_id, (unsigned long)t->len);
-  tapasco_device_free(devctx, t->handle, t->flags, s_id, t->len);
+  tapasco_device_free(devctx, t->handle, t->len, t->flags, s_id);
   return res;
 }
 

--- a/runtime/arch/common/src/tapasco_jobs.c
+++ b/runtime/arch/common/src/tapasco_jobs.c
@@ -168,7 +168,8 @@ inline tapasco_res_t tapasco_jobs_get_arg(tapasco_jobs_t *jobs,
                                           void *arg_value) {
   assert(jobs);
 
-  if (arg_len != sizeof(uint8_t) && arg_len != sizeof(uint16_t) && arg_len != sizeof(uint32_t) && arg_len != sizeof(uint64_t))
+  if (arg_len != sizeof(uint8_t) && arg_len != sizeof(uint16_t) &&
+      arg_len != sizeof(uint32_t) && arg_len != sizeof(uint64_t))
     return TAPASCO_ERR_INVALID_ARG_SIZE;
   if (arg_idx >= TAPASCO_JOB_MAX_ARGS)
     return TAPASCO_ERR_INVALID_ARG_INDEX;
@@ -187,7 +188,8 @@ inline tapasco_res_t tapasco_jobs_set_arg(tapasco_jobs_t *jobs,
                                           void const *arg_value) {
   assert(jobs);
 
-  if (arg_len != sizeof(uint8_t) && arg_len != sizeof(uint16_t) && arg_len != sizeof(uint32_t) && arg_len != sizeof(uint64_t))
+  if (arg_len != sizeof(uint8_t) && arg_len != sizeof(uint16_t) &&
+      arg_len != sizeof(uint32_t) && arg_len != sizeof(uint64_t))
     return TAPASCO_ERR_INVALID_ARG_SIZE;
   if (arg_idx >= TAPASCO_JOB_MAX_ARGS)
     return TAPASCO_ERR_INVALID_ARG_INDEX;

--- a/runtime/arch/common/src/tapasco_memory.c
+++ b/runtime/arch/common/src/tapasco_memory.c
@@ -161,8 +161,9 @@ tapasco_res_t tapasco_device_alloc(tapasco_devctx_t *devctx,
   return TAPASCO_ERR_OUT_OF_MEMORY;
 }
 
-void tapasco_device_free(tapasco_devctx_t *devctx, tapasco_handle_t handle, size_t len,
-                         tapasco_device_alloc_flag_t const flags, ...) {
+void tapasco_device_free(tapasco_devctx_t *devctx, tapasco_handle_t handle,
+                         size_t len, tapasco_device_alloc_flag_t const flags,
+                         ...) {
   platform_devctx_t *p = devctx->pdctx;
   LOG(LALL_MEM, "freeing handle " PRIhandle, handle);
   if (flags & TAPASCO_DEVICE_ALLOC_FLAGS_PE_LOCAL) {

--- a/runtime/arch/common/src/tapasco_memory.c
+++ b/runtime/arch/common/src/tapasco_memory.c
@@ -161,7 +161,7 @@ tapasco_res_t tapasco_device_alloc(tapasco_devctx_t *devctx,
   return TAPASCO_ERR_OUT_OF_MEMORY;
 }
 
-void tapasco_device_free(tapasco_devctx_t *devctx, tapasco_handle_t handle,
+void tapasco_device_free(tapasco_devctx_t *devctx, tapasco_handle_t handle, size_t len,
                          tapasco_device_alloc_flag_t const flags, ...) {
   platform_devctx_t *p = devctx->pdctx;
   LOG(LALL_MEM, "freeing handle " PRIhandle, handle);
@@ -169,11 +169,11 @@ void tapasco_device_free(tapasco_devctx_t *devctx, tapasco_handle_t handle,
     va_list ap;
     va_start(ap, flags);
     tapasco_slot_id_t slot_id = va_arg(ap, tapasco_slot_id_t);
-    size_t len = va_arg(ap, size_t);
     va_end(ap);
     tapasco_device_free_local(devctx, handle, len, flags, slot_id);
+  } else {
+    platform_dealloc(p, handle, len, PLATFORM_ALLOC_FLAGS_NONE);
   }
-  platform_dealloc(p, handle, PLATFORM_ALLOC_FLAGS_NONE);
 }
 
 tapasco_res_t tapasco_device_copy_to(tapasco_devctx_t *devctx, void const *src,

--- a/runtime/arch/include/tapasco.h
+++ b/runtime/arch/include/tapasco.h
@@ -272,7 +272,7 @@ tapasco_res_t tapasco_device_alloc(tapasco_devctx_t *dev_ctx,
  * @param handle memory chunk handle returned by @see tapasco_alloc
  * @param flags device memory allocation flags
  **/
-void tapasco_device_free(tapasco_devctx_t *dev_ctx, tapasco_handle_t handle,
+void tapasco_device_free(tapasco_devctx_t *dev_ctx, tapasco_handle_t handle, size_t len,
                          tapasco_device_alloc_flag_t const flags, ...);
 
 /**

--- a/runtime/arch/include/tapasco.h
+++ b/runtime/arch/include/tapasco.h
@@ -272,8 +272,9 @@ tapasco_res_t tapasco_device_alloc(tapasco_devctx_t *dev_ctx,
  * @param handle memory chunk handle returned by @see tapasco_alloc
  * @param flags device memory allocation flags
  **/
-void tapasco_device_free(tapasco_devctx_t *dev_ctx, tapasco_handle_t handle, size_t len,
-                         tapasco_device_alloc_flag_t const flags, ...);
+void tapasco_device_free(tapasco_devctx_t *dev_ctx, tapasco_handle_t handle,
+                         size_t len, tapasco_device_alloc_flag_t const flags,
+                         ...);
 
 /**
  * Copys memory from main memory to the FPGA device.

--- a/runtime/arch/include/tapasco.hpp
+++ b/runtime/arch/include/tapasco.hpp
@@ -273,9 +273,9 @@ struct Tapasco {
    * Frees a previously allocated chunk of device memory.
    * @param handle memory chunk handle returned by @see alloc
    **/
-  void free(tapasco_handle_t const handle,
+  void free(tapasco_handle_t const handle, size_t const len,
             tapasco_device_alloc_flag_t const flags) const noexcept {
-    tapasco_device_free(devctx, handle, flags);
+    tapasco_device_free(devctx, handle, len, flags);
   }
 
   /**

--- a/runtime/common/src/gen_mem.c
+++ b/runtime/common/src/gen_mem.c
@@ -43,13 +43,13 @@ int roundUp(int numToRound, int multiple) {
 }
 
 void print_chain(block_t *root) {
-    block_t *cur = root;
-    GEN_MEM_LOG("CHAIN ");
-    while(cur != NULL) {
-        GEN_MEM_LOG("%X (%zdB) -> ", cur->base, cur->range);
-        cur = cur->next;
-    }
-    GEN_MEM_LOG("NULL\n");
+  block_t *cur = root;
+  GEN_MEM_LOG("CHAIN ");
+  while (cur != NULL) {
+    GEN_MEM_LOG("%X (%zdB) -> ", cur->base, cur->range);
+    cur = cur->next;
+  }
+  GEN_MEM_LOG("NULL\n");
 }
 
 block_t *gen_mem_create(addr_t const base, size_t const range) {
@@ -68,13 +68,13 @@ block_t *gen_mem_create(addr_t const base, size_t const range) {
 }
 
 void gen_mem_destroy(block_t **root) {
-    block_t *cur = *root;
-    while(cur != NULL) {
-        block_t *nxt = cur->next;
-        free(cur);
-        cur = nxt;
-    }
-    *root = NULL;
+  block_t *cur = *root;
+  while (cur != NULL) {
+    block_t *nxt = cur->next;
+    free(cur);
+    cur = nxt;
+  }
+  *root = NULL;
 }
 
 addr_t gen_mem_next_base(block_t *root) {
@@ -100,7 +100,7 @@ addr_t gen_mem_malloc(block_t **root, size_t const l) {
   }
   if (!prv)
     return INVALID_ADDRESS;
-  if(prv->next == NULL) {
+  if (prv->next == NULL) {
     block_t *nb = (block_t *)malloc(sizeof(*nb));
     nxt = nb;
     prv->next = nb;
@@ -124,7 +124,7 @@ void gen_mem_free(block_t **root, addr_t const p, size_t const l) {
   assert(root || "argument to gen_mem_free may not be NULL");
   GEN_MEM_LOG("freeing 0x%08lx - 0x%08lx\n", (unsigned long)p,
               p + roundUp(l, GEN_MEM_ALIGNMENT));
-  if(l == 0) {
+  if (l == 0) {
     GEN_MEM_LOG("Can't free empty range\n");
     return;
   }

--- a/runtime/examples/arrayinit/arrayinit-example.c
+++ b/runtime/examples/arrayinit/arrayinit-example.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv) {
                                            TAPASCO_DEVICE_COPY_BLOCKING));
     unsigned int errs = check_array(&arr[SZ * run], SZ);
     printf("\nRUN %d %s\n", run, errs == 0 ? "OK" : "NOT OK");
-    tapasco_device_free(dev, h, 0);
+    tapasco_device_free(dev, h, SZ * sizeof(int), 0);
     tapasco_device_release_job_id(dev, j_id);
   }
 

--- a/runtime/examples/arraysum/arraysum-example.c
+++ b/runtime/examples/arraysum/arraysum-example.c
@@ -108,7 +108,8 @@ int main(int argc, char **argv) {
     check_tapasco(tapasco_device_job_get_return(dev, j_id, sizeof(r), &r));
     printf("FPGA output for run %d: %d\n", run, r);
     printf("\nRUN %d %s\n", run, r == golden ? "OK" : "NOT OK");
-    tapasco_device_free(dev, h, SZ * sizeof(int), TAPASCO_DEVICE_ALLOC_FLAGS_NONE);
+    tapasco_device_free(dev, h, SZ * sizeof(int),
+                        TAPASCO_DEVICE_ALLOC_FLAGS_NONE);
     tapasco_device_release_job_id(dev, j_id);
   }
 

--- a/runtime/examples/arraysum/arraysum-example.c
+++ b/runtime/examples/arraysum/arraysum-example.c
@@ -108,7 +108,7 @@ int main(int argc, char **argv) {
     check_tapasco(tapasco_device_job_get_return(dev, j_id, sizeof(r), &r));
     printf("FPGA output for run %d: %d\n", run, r);
     printf("\nRUN %d %s\n", run, r == golden ? "OK" : "NOT OK");
-    tapasco_device_free(dev, h, TAPASCO_DEVICE_ALLOC_FLAGS_NONE);
+    tapasco_device_free(dev, h, SZ * sizeof(int), TAPASCO_DEVICE_ALLOC_FLAGS_NONE);
     tapasco_device_release_job_id(dev, j_id);
   }
 

--- a/runtime/examples/arrayupdate/arrayupdate-example.c
+++ b/runtime/examples/arrayupdate/arrayupdate-example.c
@@ -126,7 +126,7 @@ int main(int argc, char **argv) {
     printf("TPC output for run %d: %d\n", run, r);
     unsigned int errs = check_arrays(&arr[SZ * run], &golden_arr[SZ * run], SZ);
     printf("\nRUN %d %s\n", run, errs == 0 ? "OK" : "NOT OK");
-    tapasco_device_free(dev, h, 0);
+    tapasco_device_free(dev, h, SZ * sizeof(int), 0);
     tapasco_device_release_job_id(dev, j_id);
   }
 

--- a/runtime/examples/memcheck/memcheck-mt.c
+++ b/runtime/examples/memcheck/memcheck-mt.c
@@ -113,7 +113,7 @@ static void *test_thread(void *p) {
       merr += 1;
     }
     __atomic_add_fetch(&errs, merr, __ATOMIC_SEQ_CST);
-    tapasco_device_free(dev, h, 0);
+    tapasco_device_free(dev, h, arr_szs[s] * sizeof(int), 0);
 
     if (!merr)
       /*printf("%ld: Array size %zd (%zd byte) ok!\n",

--- a/runtime/examples/memcheck/memcheck.c
+++ b/runtime/examples/memcheck/memcheck.c
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
     check_fpga(
         tapasco_device_copy_from(dev, h, rarr, arr_szs[s] * sizeof(int), 0));
 
-    tapasco_device_free(dev, h, 0);
+    tapasco_device_free(dev, h, arr_szs[s] * sizeof(int), 0);
 
     int merr = compare_arrays(arr, rarr, arr_szs[s]);
     errs = +merr;

--- a/runtime/examples/tapasco-benchmark/TransferSpeed.hpp
+++ b/runtime/examples/tapasco-benchmark/TransferSpeed.hpp
@@ -111,7 +111,7 @@ private:
         bytes += chunk_sz;
       }
     }
-    tapasco.free(h, TAPASCO_DEVICE_ALLOC_FLAGS_NONE);
+    tapasco.free(h, chunk_sz, TAPASCO_DEVICE_ALLOC_FLAGS_NONE);
     return r;
   }
 
@@ -133,7 +133,7 @@ private:
         bytes += chunk_sz;
       }
     }
-    tapasco.free(h, TAPASCO_DEVICE_ALLOC_FLAGS_NONE);
+    tapasco.free(h, chunk_sz, TAPASCO_DEVICE_ALLOC_FLAGS_NONE);
     return r;
   }
 

--- a/runtime/platform/common/src/platform_device_operations.c
+++ b/runtime/platform/common/src/platform_device_operations.c
@@ -99,14 +99,14 @@ platform_res_t default_alloc_driver(platform_devctx_t *devctx, size_t const len,
   return PLATFORM_SUCCESS;
 }
 
-platform_res_t default_dealloc_driver(platform_devctx_t *devctx,
+platform_res_t default_dealloc_driver(platform_devctx_t *devctx, size_t const len,
                                       platform_mem_addr_t const addr,
                                       platform_alloc_flags_t const flags) {
   DEVLOG(devctx->dev_id, LPLL_MM,
          "freeing memory at " PRImem " with flags " PRIflags, addr,
          (CSTflags)flags);
   struct tlkm_mm_cmd cmd = {
-      .sz = 0,
+      .sz = len,
       .dev_addr = addr,
   };
   long ret = ioctl(devctx->fd_ctrl, TLKM_DEV_IOCTL_FREE, &cmd);
@@ -137,15 +137,13 @@ platform_res_t default_alloc_host(platform_devctx_t *devctx, size_t const len,
   return PLATFORM_SUCCESS;
 }
 
-platform_res_t default_dealloc_host(platform_devctx_t *devctx,
+platform_res_t default_dealloc_host(platform_devctx_t *devctx, size_t const len,
                                     platform_mem_addr_t const addr,
                                     platform_alloc_flags_t const flags) {
   default_platform_t *pp = (default_platform_t *)devctx->private_data;
   if (pp) {
     pthread_mutex_lock(&pp->mem_mtx);
-    // TODO: This will always fail as length is 0
-    // Won't fix for now as all of this API has to be replaced anyway...
-    gen_mem_free(&pp->mem, addr, 0);
+    gen_mem_free(&pp->mem, addr, len);
     pthread_mutex_unlock(&pp->mem_mtx);
   } else {
     return PERR_TLKM_ERROR;

--- a/runtime/platform/common/src/platform_device_operations.c
+++ b/runtime/platform/common/src/platform_device_operations.c
@@ -99,7 +99,8 @@ platform_res_t default_alloc_driver(platform_devctx_t *devctx, size_t const len,
   return PLATFORM_SUCCESS;
 }
 
-platform_res_t default_dealloc_driver(platform_devctx_t *devctx, size_t const len,
+platform_res_t default_dealloc_driver(platform_devctx_t *devctx,
+                                      size_t const len,
                                       platform_mem_addr_t const addr,
                                       platform_alloc_flags_t const flags) {
   DEVLOG(devctx->dev_id, LPLL_MM,

--- a/runtime/platform/include/platform.h
+++ b/runtime/platform/include/platform.h
@@ -170,11 +170,11 @@ platform_alloc(platform_devctx_t *ctx, size_t const len,
  * @param addr Address of memory.
  **/
 static inline platform_res_t
-platform_dealloc(platform_devctx_t *ctx, platform_mem_addr_t const addr,
+platform_dealloc(platform_devctx_t *ctx, platform_mem_addr_t const addr, size_t const len,
                  platform_alloc_flags_t const flags) {
   assert(ctx);
   assert(ctx->dops.dealloc);
-  return ctx->dops.dealloc(ctx, addr, flags);
+  return ctx->dops.dealloc(ctx, len, addr, flags);
 }
 
 /**

--- a/runtime/platform/include/platform.h
+++ b/runtime/platform/include/platform.h
@@ -170,8 +170,8 @@ platform_alloc(platform_devctx_t *ctx, size_t const len,
  * @param addr Address of memory.
  **/
 static inline platform_res_t
-platform_dealloc(platform_devctx_t *ctx, platform_mem_addr_t const addr, size_t const len,
-                 platform_alloc_flags_t const flags) {
+platform_dealloc(platform_devctx_t *ctx, platform_mem_addr_t const addr,
+                 size_t const len, platform_alloc_flags_t const flags) {
   assert(ctx);
   assert(ctx->dops.dealloc);
   return ctx->dops.dealloc(ctx, len, addr, flags);

--- a/runtime/platform/include/platform_device_operations.h
+++ b/runtime/platform/include/platform_device_operations.h
@@ -43,7 +43,8 @@ platform_res_t default_alloc_driver(platform_devctx_t *devctx, size_t const len,
                                     platform_mem_addr_t *addr,
                                     platform_alloc_flags_t const flags);
 
-platform_res_t default_dealloc_driver(platform_devctx_t *devctx, size_t const len,
+platform_res_t default_dealloc_driver(platform_devctx_t *devctx,
+                                      size_t const len,
                                       platform_mem_addr_t const addr,
                                       platform_alloc_flags_t const flags);
 

--- a/runtime/platform/include/platform_device_operations.h
+++ b/runtime/platform/include/platform_device_operations.h
@@ -9,7 +9,7 @@ typedef struct platform_device_operations {
   platform_res_t (*alloc)(platform_devctx_t *devctx, size_t const len,
                           platform_mem_addr_t *addr,
                           platform_alloc_flags_t const flags);
-  platform_res_t (*dealloc)(platform_devctx_t *devctx,
+  platform_res_t (*dealloc)(platform_devctx_t *devctx, size_t const len,
                             platform_mem_addr_t const addr,
                             platform_alloc_flags_t const flags);
   platform_res_t (*read_mem)(platform_devctx_t const *devctx,
@@ -43,7 +43,7 @@ platform_res_t default_alloc_driver(platform_devctx_t *devctx, size_t const len,
                                     platform_mem_addr_t *addr,
                                     platform_alloc_flags_t const flags);
 
-platform_res_t default_dealloc_driver(platform_devctx_t *devctx,
+platform_res_t default_dealloc_driver(platform_devctx_t *devctx, size_t const len,
                                       platform_mem_addr_t const addr,
                                       platform_alloc_flags_t const flags);
 
@@ -51,7 +51,7 @@ platform_res_t default_alloc_host(platform_devctx_t *devctx, size_t const len,
                                   platform_mem_addr_t *addr,
                                   platform_alloc_flags_t const flags);
 
-platform_res_t default_dealloc_host(platform_devctx_t *devctx,
+platform_res_t default_dealloc_host(platform_devctx_t *devctx, size_t const len,
                                     platform_mem_addr_t const addr,
                                     platform_alloc_flags_t const flags);
 

--- a/runtime/platform/include/platform_types.h
+++ b/runtime/platform/include/platform_types.h
@@ -22,6 +22,7 @@
 #include "platform_components.h"
 #include <stdint.h>
 #include <stdlib.h>
+#include <sys/types.h>
 #include <tlkm_access.h>
 #include <tlkm_ioctl_cmds.h>
 


### PR DESCRIPTION
Frees were ineffectual as all length were 0.

Fixed by propagating the length of frees on free.