### PR TITLE
This commit enables users to chain key value pairs separating them by…

### DIFF
--- a/toolflow/scala/src/main/scala/tapasco/parser/FeatureParsers.scala
+++ b/toolflow/scala/src/main/scala/tapasco/parser/FeatureParsers.scala
@@ -29,7 +29,7 @@ private object FeatureParsers {
   def feature: Parser[Feature] =
     (qstring.opaque("feature name").! ~ ws ~/
       featureBegin ~ ws ~/
-      (featureKeyValue ~ ws).rep ~ ws ~/
+      commaSeparatedKeyVal ~/
       featureEnd ~ ws)
       .map(p => Feature(p._1, FMap(p._2.toMap)))
 
@@ -40,6 +40,9 @@ private object FeatureParsers {
   val featureEndChars = "})]"
   val featureMarks = (featureBeginChars ++ featureEndChars) map (_.toString)
   val featureAssigns = Seq("->", "=", ":=", ":")
+
+  def commaSeparatedKeyVal: Parser[Seq[(String, FString)]] =
+    ((featureKeyValue ~ "," ~ ws) | (featureKeyValue)).rep
 
   def featureBegin: Parser[Unit] =
     CharIn(featureBeginChars).opaque(s"begin of feature mark, one of '$featureBeginChars'")
@@ -58,7 +61,7 @@ private object FeatureParsers {
       .opaque("feature value for given key") map (a => FString(a))
 
   def featureKeyValue: Parser[(String, FString)] =
-    featureKey ~ ws ~/
-      featureAssign.opaque("feature assignment operator, one of '->', '=', ':=' or ':'") ~ ws ~/
+    featureKey ~ ws ~
+      featureAssign.opaque("feature assignment operator, one of '->', '=', ':=' or ':'") ~ ws ~
       featureVal ~ ws
 }


### PR DESCRIPTION
… using a single comma. This fixes an issue of the documentation which describes the command line key value pair syntax as `[<KEYVALUE> [, <KEYVALUE>]*]`. Prior to this commit the parser did not accept the separator  though.

## Background:

`$ tapasco -h features`

outputs the following syntax description for the `--features` flag given on the command line. 

```
FEATURES SYNTAX
  The hardware designs generated by TaPaSCo offer a great amount of flexibility 
  using a dynamic plug-in interface; a plug-in can extend or modify the resulting 
  design. By default, most plug-ins are disabled and must be activated by the 
  user. This is done via a Feature specification: A Feature contains the 
  configuration parameters for a plug-in. The basic command line syntax is as 
  follows:
  
  FEATURE                       <NAME> <BEGIN> [<KEYVALUE> [, <KEYVALUE>]*] <END>
    NAME                          any quoted or unquoted string
      BEGIN                         one of '[', '{' or '('
      END                           one of ']', '}, or ')'
    KEYVALUE                      <KEY> <ASSIGN> <VALUE>
      KEY                           any quoted or unquoted string
      ASSIGN                        either '->', '=', ':=' or ':'
      VALUE                         any quoted or unquoted string
  
  Examples:                     'OLED' [enabled -> true]
                                'LEDS' { enabled: true, 
                                inputs: "/system/LED_*" }
                                'BlueDMA' (enabled = 
                                true)

```

This implies that `<KEYVALUE>` must be separated by a single comma. The previous parser did only accept key-value pairs separated by whitespace, though.