### PR TITLE
Fix the CLI parser for TaPaSCo features;

### DIFF
--- a/toolflow/scala/src/main/scala/tapasco/parser/FeatureParsers.scala
+++ b/toolflow/scala/src/main/scala/tapasco/parser/FeatureParsers.scala
@@ -29,7 +29,7 @@ private object FeatureParsers {
   def feature: Parser[Feature] =
     (qstring.opaque("feature name").! ~ ws ~/
       featureBegin ~ ws ~/
-      commaSeparatedKeyVal ~/
+      commaSeparatedKeyVal ~ ws ~/
       featureEnd ~ ws)
       .map(p => Feature(p._1, FMap(p._2.toMap)))
 
@@ -42,7 +42,7 @@ private object FeatureParsers {
   val featureAssigns = Seq("->", "=", ":=", ":")
 
   def commaSeparatedKeyVal: Parser[Seq[(String, FString)]] =
-    ((featureKeyValue ~ "," ~ ws) | (featureKeyValue)).rep
+    featureKeyValue.rep(sep = ws~","~ws~/)
 
   def featureBegin: Parser[Unit] =
     CharIn(featureBeginChars).opaque(s"begin of feature mark, one of '$featureBeginChars'")

--- a/toolflow/scala/src/test/scala/tapasco/parser/BasicParserSpec.scala
+++ b/toolflow/scala/src/test/scala/tapasco/parser/BasicParserSpec.scala
@@ -158,6 +158,11 @@ private object BasicParserSpec {
     sep <- sepCharGen
   } yield s"$ws1$sep$ws2"
 
+  val commaSepStringGen : Gen[String] = for {
+    ws1 <- wsStringGen
+    ws2 <- wsStringGen
+  } yield s"$ws1,$ws2"
+
   def interleave[A](as: Seq[A], bs: Seq[A]): Seq[A] = (as, bs) match {
     case (Seq(), bs) => bs
     case (as, Seq()) => as

--- a/toolflow/scala/src/test/scala/tapasco/parser/FeatureParsersSpec.scala
+++ b/toolflow/scala/src/test/scala/tapasco/parser/FeatureParsersSpec.scala
@@ -68,7 +68,7 @@ private object FeatureParsersSpec {
   }
 
   def featureKVs(n: Int): Gen[String] =
-    BasicParserSpec.join(0 until n map { _ => featureKeyValueGen })
+    BasicParserSpec.join(0 until n map { _ => featureKeyValueGen }, BasicParserSpec.commaSepStringGen)
 
   val featureGen: Gen[String] = for {
     begin <- featureBeginGen


### PR DESCRIPTION
Correctly parse comma-separated key-value pairs for features; Fixes
previously existing problems with single key-value pairs;