### PR TITLE
Hotfix for boot image generation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -310,7 +310,7 @@ build_kernel_fedora_31_debug:
     - dnf -y install kernel-devel make gcc gcc-c++ elfutils-libelf-devel cmake ncurses-devel python libatomic git rpm-build
   artifacts:
     paths:
-      - build/tapasco-*-Linux.rpm
+      - build/tapasco-2018.2.1-Linux.rpm
   extends: .build_tapasco
 
 build_tapasco_fedora_24:
@@ -386,7 +386,7 @@ build_tapasco_fedora_31_debug:
     - apt-get -y update && apt-get -y install build-essential linux-headers-generic python cmake libelf-dev libncurses-dev git rpm
   artifacts:
     paths:
-      - build/tapasco-*-Linux.deb
+      - build/tapasco-2018.2.1-Linux.deb
   extends: .build_tapasco
 
 build_tapasco_ubuntu_16_04:

--- a/README.md
+++ b/README.md
@@ -113,29 +113,29 @@ We provided pre-compiled packages for many popular Linux distributions. All pack
 ### Ubuntu 16.04
 [Kernel Driver](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/tlkm/tlkm.ko?job=build_kernel_ubuntu_16_04)
 [Kernel Driver Debug](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/tlkm/tlkm.ko?job=build_kernel_ubuntu_16_04_debug)
-[Runtime (DEB)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2019.6.0-Linux.deb?job=build_tapasco_ubuntu_16_04)
-[Runtime Debug (DEB)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2019.6.0-Linux.deb?job=build_tapasco_ubuntu_16_04_debug)
+[Runtime (DEB)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2018.2.1-Linux.deb?job=build_tapasco_ubuntu_16_04)
+[Runtime Debug (DEB)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2018.2.1-Linux.deb?job=build_tapasco_ubuntu_16_04_debug)
 
 ### Ubuntu 18.04
 [Kernel Driver](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/tlkm/tlkm.ko?job=build_kernel_ubuntu_18_04)
 [Kernel Driver Debug](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/tlkm/tlkm.ko?job=build_kernel_ubuntu_18_04_debug)
-[Runtime (DEB)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2019.6.0-Linux.deb?job=build_tapasco_ubuntu_18_04)
-[Runtime Debug (DEB)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2019.6.0-Linux.deb?job=build_tapasco_ubuntu_18_04_debug)
+[Runtime (DEB)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2018.2.1-Linux.deb?job=build_tapasco_ubuntu_18_04)
+[Runtime Debug (DEB)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2018.2.1-Linux.deb?job=build_tapasco_ubuntu_18_04_debug)
 
 ### Fedora 27
 [Kernel Driver](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/tlkm/tlkm.ko?job=build_kernel_fedora_27)
 [Kernel Driver Debug](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/tlkm/tlkm.ko?job=build_kernel_fedora_27_debug)
-[Runtime (RPM)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2019.6.0-Linux.rpm?job=build_tapasco_fedora_27)
-[Runtime Debug (RPM)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2019.6.0-Linux.rpm?job=build_tapasco_fedora_27_debug)
+[Runtime (RPM)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2018.2.1-Linux.rpm?job=build_tapasco_fedora_27)
+[Runtime Debug (RPM)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2018.2.1-Linux.rpm?job=build_tapasco_fedora_27_debug)
 
 ### Fedora 28
 [Kernel Driver](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/tlkm/tlkm.ko?job=build_kernel_fedora_28)
 [Kernel Driver Debug](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/tlkm/tlkm.ko?job=build_kernel_fedora_28_debug)
-[Runtime (RPM)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2019.6.0-Linux.rpm?job=build_tapasco_fedora_28)
-[Runtime Debug (RPM)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2019.6.0-Linux.rpm?job=build_tapasco_fedora_28_debug)
+[Runtime (RPM)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2018.2.1-Linux.rpm?job=build_tapasco_fedora_28)
+[Runtime Debug (RPM)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2018.2.1-Linux.rpm?job=build_tapasco_fedora_28_debug)
 
 ### Fedora 29
 [Kernel Driver](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/tlkm/tlkm.ko?job=build_kernel_fedora_29)
 [Kernel Driver Debug](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/tlkm/tlkm.ko?job=build_kernel_fedora_29_debug)
-[Runtime (RPM)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2019.6.0-Linux.rpm?job=build_tapasco_fedora_29)
-[Runtime Debug (RPM)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2019.6.0-Linux.rpm?job=build_tapasco_fedora_29_debug)
+[Runtime (RPM)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2018.2.1-Linux.rpm?job=build_tapasco_fedora_29)
+[Runtime Debug (RPM)](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/-/jobs/artifacts/master/raw/build/tapasco-2018.2.1-Linux.rpm?job=build_tapasco_fedora_29_debug)


### PR DESCRIPTION
This commit should fix some problems occurring during the boot image generation by using absolute paths and limiting the job count.
Tested on Fedora 30 (Linux 5.2.8) with Vivado 2019.1 for zedboard and pynq.
As discussed in #122 the PR will be applied to the feature/boot_image_generator branch.