### PR TITLE
Silence warning if lmstat is not found

### DIFF
--- a/toolflow/scala/src/main/scala/tapasco/util/FlexLicenceManagerStatus.scala
+++ b/toolflow/scala/src/main/scala/tapasco/util/FlexLicenceManagerStatus.scala
@@ -26,7 +26,7 @@ import scala.sys.process._
   * licenses / features. If lmstat is not found, delivers default values.
   **/
 object FlexLicenceManagerStatus {
-  private[this] val _has_lmstat = "sh -c 'which lmstat > /dev/null 2>&1'".! == 0
+  private[this] val _has_lmstat = "sh -c which lmstat > /dev/null 2>&1".! == 0
 
   /**
     * Returns a map of license/features names to a pair of Ints representing

--- a/toolflow/scala/src/main/scala/tapasco/util/FlexLicenceManagerStatus.scala
+++ b/toolflow/scala/src/main/scala/tapasco/util/FlexLicenceManagerStatus.scala
@@ -26,7 +26,7 @@ import scala.sys.process._
   * licenses / features. If lmstat is not found, delivers default values.
   **/
 object FlexLicenceManagerStatus {
-  private[this] val _has_lmstat = "sh -c which lmstat > /dev/null 2>&1".! == 0
+  private[this] val _has_lmstat = Seq("sh", "-c", "which lmstat > /dev/null 2>&1").! == 0
 
   /**
     * Returns a map of license/features names to a pair of Ints representing

--- a/toolflow/scala/src/main/scala/tapasco/util/FlexLicenceManagerStatus.scala
+++ b/toolflow/scala/src/main/scala/tapasco/util/FlexLicenceManagerStatus.scala
@@ -26,7 +26,7 @@ import scala.sys.process._
   * licenses / features. If lmstat is not found, delivers default values.
   **/
 object FlexLicenceManagerStatus {
-  private[this] val _has_lmstat = "which lmstat".! == 0
+  private[this] val _has_lmstat = "sh -c 'which lmstat > /dev/null 2>&1'".! == 0
 
   /**
     * Returns a map of license/features names to a pair of Ints representing


### PR DESCRIPTION
As discussed in #110, the warning that the `lmstat`-command was not found can be confusing for new users. 

As, if found in the system, `lmstat` can be used by `FlexLicenceManagerStatus` to provide useful information about the number of available licenses for different features to the TaPaSCo toolflow, I did not remove the dependency/usage of `lmstat` completely, but rather silenced the warning in the TaPaSCo output.