### PR TITLE
Make the maximum DSE frequency configurable as a single value in the platform JSON

### DIFF
--- a/toolflow/scala/src/main/scala/tapasco/base/Platform.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/Platform.scala
@@ -38,7 +38,8 @@ case class Platform(
                      boardPreset: Option[String],
                      boardPartRepository: Option[String],
                      targetUtilization: Int,
-                     supportedFrequencies: Seq[Int],
+                     private val _supportedFrequencies: Option[Seq[Int]],
+                     maxFrequency : Int,
                      private val _slotCount: Option[Int],
                      description: Option[String],
                      private val _benchmark: Option[Path],
@@ -48,6 +49,7 @@ case class Platform(
   val tclLibrary: Path = resolve(_tclLibrary)
   val benchmark: Option[Benchmark] = _benchmark flatMap (p => Benchmark.from(resolve(p)).toOption)
   val slotCount: Int = _slotCount getOrElse Platform.DEFAULT_SLOTCOUNT
+  val supportedFrequencies : Seq[Int] = _supportedFrequencies.getOrElse(50 to maxFrequency by 5)
   require(mustExist(tclLibrary), "Tcl library %s does not exist".format(tclLibrary.toString))
 }
 

--- a/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
@@ -346,7 +346,8 @@ package object json {
       (JsPath \ "BoardPreset").readNullable[String](minLength[String](4)) ~
       (JsPath \ "BoardPartRepository").readNullable[String](minLength[String](4)) ~
       (JsPath \ "TargetUtilization").read[Int](min(5) keepAnd max(100)) ~
-      (JsPath \ "SupportedFrequencies").readNullable[Seq[Int]](minLength[Seq[Int]](1)).map(_ getOrElse (50 to 450 by 5)) ~
+      (JsPath \ "SupportedFrequencies").readNullable[Seq[Int]](minLength[Seq[Int]](1)) ~
+      (JsPath \ "MaximumFrequency").readNullable[Int].map(_.getOrElse(450)) ~
       (JsPath \ "SlotCount").readNullable[Int](min(1) keepAnd max(255)) ~
       (JsPath \ "Description").readNullable[String](minLength[String](1)) ~
       (JsPath \ "Benchmark").readNullable[Path] ~
@@ -364,7 +365,8 @@ package object json {
       (JsPath \ "BoardPreset").writeNullable[String] ~
       (JsPath \ "BoardPartRepository").writeNullable[String] ~
       (JsPath \ "TargetUtilization").write[Int] ~
-      (JsPath \ "SupportedFrequencies").write[Seq[Int]] ~
+      (JsPath \ "SupportedFrequencies").writeNullable[Seq[Int]] ~
+      (JsPath \ "MaximumFrequency").write[Int] ~
       (JsPath \ "SlotCount").writeNullable[Int] ~
       (JsPath \ "Description").writeNullable[String] ~
       (JsPath \ "Benchmark").writeNullable[Path] ~

--- a/toolflow/scala/src/test/resources/json-examples/correct-platform.json
+++ b/toolflow/scala/src/test/resources/json-examples/correct-platform.json
@@ -7,6 +7,7 @@
   "BoardPreset": "ZC706",
   "TargetUtilization": 55,
   "SlotCount": 64,
+  "MaximumFrequency" : 420,
   "SupportedFrequencies": [
     250,
     200,

--- a/toolflow/scala/src/test/resources/json-examples/unknown-platform.json
+++ b/toolflow/scala/src/test/resources/json-examples/unknown-platform.json
@@ -12,6 +12,7 @@
   ],
   "TargetUtilization": 55,
   "SlotCount": 64,
+  "MaximumFrequency" : 420,
   "SupportedFrequencies": [
     250,
     200,

--- a/toolflow/scala/src/test/scala/tapasco/base/PlatformTest.scala
+++ b/toolflow/scala/src/test/scala/tapasco/base/PlatformTest.scala
@@ -47,6 +47,7 @@ class PlatformSpec extends TaPaSCoSpec with Matchers {
     c.boardPart should equal(Some("xilinx.com:zc706:part0:1.1"))
     c.boardPreset should equal(Some("ZC706"))
     c.targetUtilization should equal(55)
+    c.maxFrequency should equal(420)
     c.supportedFrequencies should contain inOrderOnly(250, 200, 150, 100, 42)
   }
 
@@ -60,6 +61,7 @@ class PlatformSpec extends TaPaSCoSpec with Matchers {
     c.boardPart should equal(Some("xilinx.com:zc706:part0:1.1"))
     c.boardPreset should equal(Some("ZC706"))
     c.targetUtilization should equal(55)
+    c.maxFrequency should equal(420)
     c.supportedFrequencies should contain inOrderOnly(250, 200, 150, 100, 42)
   }
 


### PR DESCRIPTION
This addresses the problem brought up in #100. In addition to the list of supported frequencies, the maximum DSE frequency is now configurable as a single scalar value in the `platform.json`

Behavior:

* If both `SupportedFrequencies` and `MaximumFrequency` are given, the list of supported frequencies takes precedence over the maximum frequency.

* If the field `SupportedFrequencies` is missing from the `platform.json`, the list of supported frequencies will equal the list of frequencies from `50` to the given `MaximumFrequency`, in steps of `5`

* If `MaximumFrequency` is also not given, it defaults to `450 MHz`.

If possible, please await the results of the CI pipeline before merging this pull request.