### PR TITLE
Correctly notify ReportManager of changes to the basepath

### DIFF
--- a/toolflow/scala/src/main/scala/tapasco/filemgmt/FileAssetManager.scala
+++ b/toolflow/scala/src/main/scala/tapasco/filemgmt/FileAssetManager.scala
@@ -137,7 +137,7 @@ final object FileAssetManager extends Publisher {
           _dirs.synchronized {
             _dirs += base -> path
           }
-          if (base equals Entities.Cores) reports.clear(Some(Set(path)))
+          if (base equals Entities.Cores) reports.basePathListener.update(BasePathManager.BasePathChanged(Entities.Cores, path))
           restartWatcher()
           publish(Events.BasePathChanged(base, path))
       }

--- a/toolflow/scala/src/main/scala/tapasco/filemgmt/ReportManager.scala
+++ b/toolflow/scala/src/main/scala/tapasco/filemgmt/ReportManager.scala
@@ -104,7 +104,7 @@ class ReportManager(var _base: Path) extends Publisher {
   /** Returns SynthesisReport for given core and Architecture/Platform combination. **/
   def synthReport(name: String, archName: String, platformName: String): Option[SynthesisReport] = {
     val bp = _base.resolve(name).resolve(archName).resolve(platformName)
-    _logger.trace("looking for SynthesisReport of {}@{}@{} in {}", name, archName, platformName, bp)
+    _logger.info("looking for SynthesisReport of {}@{}@{} in {}", name, archName, platformName, bp)
     val files = _synthReportCache.files filter (f => f.startsWith(bp))
     if (files.size > 1) {
       _logger.warn("found more than one SynthesisReport of {}@{}@{} in {}: {}",


### PR DESCRIPTION
Addresses #103, to make sure that the `ReportManager` is correctly notified of changes to the basepath, so it will search for synthesis/core reports in the correct directories.