### PR TITLE
Feature/increase clock cycles limit

### DIFF
--- a/toolflow/scala/src/main/scala/tapasco/activity/Import.scala
+++ b/toolflow/scala/src/main/scala/tapasco/activity/Import.scala
@@ -55,7 +55,7 @@ object Import {
     * @param skipEval Do not perform out-of-context synthesis for resource estimation (optional).
     * @param cfg      Implicit [[base.Configuration]].
     **/
-  def apply(zip: Path, id: Kernel.Id, t: Target, acc: Option[Int], skipEval: Option[Boolean],
+  def apply(zip: Path, id: Kernel.Id, t: Target, acc: Option[Long], skipEval: Option[Boolean],
             optimization: Int, synthOptions: Option[String] = None)
            (implicit cfg: Configuration): Boolean = {
     // get VLNV from the file

--- a/toolflow/scala/src/main/scala/tapasco/base/Core.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/Core.scala
@@ -36,7 +36,7 @@ case class Core(
                  version: String,
                  private val _target: TargetDesc,
                  description: Option[String],
-                 averageClockCycles: Option[Int]
+                 averageClockCycles: Option[Long]
                ) extends Description(descPath) {
   val zipPath: Path = resolve(_zipPath).toAbsolutePath
   require(mustExist(zipPath), "zip file %s does not exist".format(zipPath.toString))

--- a/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
@@ -182,7 +182,7 @@ package object json {
       (JsPath \ "Version").read[String](minLength[String](1)) ~
       (JsPath \ "Target").read[TargetDesc] ~
       (JsPath \ "Description").readNullable[String] ~
-      (JsPath \ "AverageClockCycles").readNullable[Int]
+      (JsPath \ "AverageClockCycles").readNullable[Long]
     ) (Core.apply _)
   implicit val coreWrites: Writes[Core] = (
     (JsPath \ "DescPath").write[Path].transform((js: JsObject) => js - "DescPath") ~
@@ -192,7 +192,7 @@ package object json {
       (JsPath \ "Version").write[String] ~
       (JsPath \ "Target").write[TargetDesc] ~
       (JsPath \ "Description").writeNullable[String] ~
-      (JsPath \ "AverageClockCycles").writeNullable[Int]
+      (JsPath \ "AverageClockCycles").writeNullable[Long]
     ) (unlift(Core.unapply _))
   /* Core @} */
 

--- a/toolflow/scala/src/main/scala/tapasco/dse/Heuristics.scala
+++ b/toolflow/scala/src/main/scala/tapasco/dse/Heuristics.scala
@@ -40,7 +40,7 @@ object Heuristics {
 
   object ThroughputHeuristic extends Heuristic {
     private def findAverageClockCycles(kernel: String, target: Target)
-                                      (implicit cfg: Configuration): Int = {
+                                      (implicit cfg: Configuration): Long = {
       val cd = FileAssetManager.entities.core(kernel, target) getOrElse {
         throw new Exception("could not find core description for %s @ %s".format(kernel, target))
       }
@@ -56,7 +56,7 @@ object Heuristics {
     }
 
     def apply(bd: Composition, freq: Frequency, target: Target): Configuration => Value = cfg => {
-      val maxClockCycles: Seq[Int] = bd.composition map (ce => findAverageClockCycles(ce.kernel, target)(cfg))
+      val maxClockCycles: Seq[Long] = bd.composition map (ce => findAverageClockCycles(ce.kernel, target)(cfg))
       val t = 1.0 / (freq * 1000000.0)
       val t_irq = target.pd.benchmark map (_.latency(maxClockCycles.max) / 1000000000.0) getOrElse 0.0
       val jobsla = maxClockCycles map (_ * t + t_irq /* + t_setup*/)

--- a/toolflow/scala/src/main/scala/tapasco/jobs/Jobs.scala
+++ b/toolflow/scala/src/main/scala/tapasco/jobs/Jobs.scala
@@ -249,7 +249,7 @@ final case class ImportJob(
                             zipFile: Path,
                             id: Kernel.Id,
                             description: Option[String] = None,
-                            averageClockCycles: Option[Int] = None,
+                            averageClockCycles: Option[Long] = None,
                             skipEvaluation: Option[Boolean] = None,
                             synthOptions: Option[String] = None,
                             private val _architectures: Option[Seq[String]] = None,

--- a/toolflow/scala/src/main/scala/tapasco/jobs/executors/BulkImport.scala
+++ b/toolflow/scala/src/main/scala/tapasco/jobs/executors/BulkImport.scala
@@ -86,7 +86,7 @@ private object BulkImport extends Executor[BulkImportJob] {
     zipFile = Paths.get(fields(0)),
     id = fields(1).toInt,
     description = if (fields(2).length > 0) Some(fields(2)) else None,
-    averageClockCycles = allCatch.opt(fields(5).toInt),
+    averageClockCycles = allCatch.opt(fields(5).toLong),
     _architectures = Some(Seq(fields(3))),
     _platforms = Some(Seq(fields(4))))).toSeq
 

--- a/toolflow/scala/src/main/scala/tapasco/jobs/executors/HighLevelSynthesis.scala
+++ b/toolflow/scala/src/main/scala/tapasco/jobs/executors/HighLevelSynthesis.scala
@@ -69,7 +69,7 @@ protected object HighLevelSynthesis extends Executor[HighLevelSynthesisJob] {
         logger.trace("searching for co-simulation report for {} @ {}", k.name: Any, t)
         val rpt = FileAssetManager.reports.cosimReport(k.name, t)
         logger.trace("co-simulation report: {}", rpt)
-        val avgCC = rpt map (_.latency.avg)
+        val avgCC = rpt map (_.latency.avg.toLong)
         logger.trace("average clock cycles: {}", avgCC)
         if (avgCC.isEmpty && k.testbenchFiles.length > 0) {
           logger.warn("executed HLS with co-sim for {}, but no co-simulation report was found", k)

--- a/toolflow/scala/src/main/scala/tapasco/jobs/executors/HighLevelSynthesis.scala
+++ b/toolflow/scala/src/main/scala/tapasco/jobs/executors/HighLevelSynthesis.scala
@@ -69,7 +69,7 @@ protected object HighLevelSynthesis extends Executor[HighLevelSynthesisJob] {
         logger.trace("searching for co-simulation report for {} @ {}", k.name: Any, t)
         val rpt = FileAssetManager.reports.cosimReport(k.name, t)
         logger.trace("co-simulation report: {}", rpt)
-        val avgCC = rpt map (_.latency.avg.toLong)
+        val avgCC = rpt map (_.latency.avg)
         logger.trace("average clock cycles: {}", avgCC)
         if (avgCC.isEmpty && k.testbenchFiles.length > 0) {
           logger.warn("executed HLS with co-sim for {}, but no co-simulation report was found", k)

--- a/toolflow/scala/src/main/scala/tapasco/jobs/json/package.scala
+++ b/toolflow/scala/src/main/scala/tapasco/jobs/json/package.scala
@@ -57,7 +57,7 @@ package object json {
       (JsPath \ "Zip").read[Path] ~
       (JsPath \ "Id").read[Int](verifying[Int](_ > 0)) ~
       (JsPath \ "Description").readNullable[String] ~
-      (JsPath \ "Average Clock Cycles").readNullable[Int](verifying[Int](_ > 0)) ~
+      (JsPath \ "Average Clock Cycles").readNullable[Long](verifying[Long](_ > 0L)) ~
       (JsPath \ "Skip Evaluation").readNullable[Boolean] ~
       (JsPath \ "Synth Options").readNullable[String] ~
       (JsPath \ "Architectures").readNullable[Seq[String]] ~
@@ -70,7 +70,7 @@ package object json {
       (JsPath \ "Zip").write[Path] ~
       (JsPath \ "Id").write[Int] ~
       (JsPath \ "Description").writeNullable[String] ~
-      (JsPath \ "Average Clock Cycles").writeNullable[Int] ~
+      (JsPath \ "Average Clock Cycles").writeNullable[Long] ~
       (JsPath \ "Skip Evaluation").writeNullable[Boolean] ~
       (JsPath \ "Synth Options").writeNullable[String] ~
       (JsPath \ "Architectures").writeNullable[Seq[String]] ~

--- a/toolflow/scala/src/main/scala/tapasco/reports/CoSimReport.scala
+++ b/toolflow/scala/src/main/scala/tapasco/reports/CoSimReport.scala
@@ -41,11 +41,11 @@ object CoSimReport {
   private[this] val logger = tapasco.Logging.logger(this.getClass)
 
   /** Model of the simulated clock cycles counts per execution (minimal, average and maximal). */
-  final case class ClockCycles(min: Int, avg: Int, max: Int)
+  final case class ClockCycles(min: Long, avg: Long, max: Long)
 
   object ClockCycles {
-    private def parseOptionalInt(s: String): Int = try {
-      s.toInt
+    private def parseOptionalInt(s: String): Long = try {
+      s.toLong
     } catch {
       case e: NumberFormatException => 1
     }

--- a/toolflow/scala/src/main/scala/tapasco/task/ImportTask.scala
+++ b/toolflow/scala/src/main/scala/tapasco/task/ImportTask.scala
@@ -47,7 +47,7 @@ class ImportTask(val zip: Path,
                  val t: Target,
                  val id: Kernel.Id,
                  val onComplete: Boolean => Unit,
-                 val averageClockCycles: Option[Int] = None,
+                 val averageClockCycles: Option[Long] = None,
                  val skipEvaluation: Option[Boolean] = None,
                  val synthOptions: Option[String] = None,
                  val optimization: Int)


### PR DESCRIPTION
Use Long for representation of AverageClockCycles instead of Int to increase Limitation.

Wait for [Pipeline](https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/commit/833ffb8bbaf3e84db19caa32d0f49df4fea46a61/pipelines?ref=feature%2Fincrease-clock-cycles-limit) to finish before merging.

Fixes #113.