### PR TITLE
Use OS packages to test compose

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -135,8 +135,8 @@ build_scala_tapasco_ubuntu_19_04:
   image: ubuntu:disco
   extends: .build_scala_tapasco_ubuntu
 
- build kernel module
- as we are running in a docker instance, we cannot use tapasco-build-libs
+# build kernel module
+# as we are running in a docker instance, we cannot use tapasco-build-libs
 .build_kernel_ubuntu:
   stage: build_kernel
   retry: 2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -440,6 +440,7 @@ tapasco_hls:
   script:
     - source $XILINX_VIVADO/settings64.sh
     - apt-get -y update
+    - apt-get -y install libtinfo5
     - apt -y install ./toolflow/scala/build/distributions/tapasco_2019-10_amd64.deb
     - /opt/tapasco/tapasco-init-toolflow.sh
     - source tapasco-setup-toolflow.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -429,7 +429,7 @@ build_scala_tapasco_ubuntu_19_04:
 tapasco_hls:
   stage: build_hw
   variables:
-    VIVADO_VERSION: "2018.2"
+    VIVADO_VERSION: "2019.1"
     XILINX_VIVADO: "/opt/cad/xilinx/vivado/Vivado/${VIVADO_VERSION}"
     XILINXD_LICENSE_FILE: "/opt/cad/keys/xilinx"
   tags:
@@ -450,7 +450,7 @@ tapasco_hls:
 #  stage: build_hw
 #  retry: 2
 #  variables:
-#    VIVADO_VERSION: "2018.2"
+#    VIVADO_VERSION: "2019.1"
 #    XILINX_VIVADO: "/opt/cad/xilinx/vivado/Vivado/${VIVADO_VERSION}"
 #    XILINXD_LICENSE_FILE: "/opt/cad/keys/xilinx"
 #    PLATFORM: "pynq"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -436,9 +436,15 @@ tapasco_hls:
     - source $XILINX_VIVADO/settings64.sh
     - which vivado
     - which vivado_hls
-    - dnf -y install toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
-    - source /opt/tapasco/tapasco-setup.sh
-    - tapasco -v hls counter -p pynq
+    - curl -s "https://get.sdkman.io" | bash
+    - source "/root/.sdkman/bin/sdkman-init.sh"
+    - sdk install java 11.0.5-zulu
+    - source $XILINX_VIVADO/settings64.sh
+    - source setup.sh
+    - pushd ${TAPASCO_HOME_TOOLFLOW}/scala
+    - ./gradlew installDist
+    - popd
+    - tapasco -v --kernelDir ${TAPASCO_HOME_TOOLFLOW}/examples/kernel-examples hls counter -p pynq
 
 .tapasco_compose:
   stage: build_hw

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -426,7 +426,7 @@ build_tapasco_ubuntu_19_04_debug:
   image: ubuntu:disco
   extends: .build_tapasco_ubuntu
 
-tapasco_hls:
+tapasco_compose_ubuntu:
   stage: build_hw
   variables:
     VIVADO_VERSION: "2019.1"
@@ -445,6 +445,7 @@ tapasco_hls:
     - /opt/tapasco/tapasco-init-toolflow.sh
     - source tapasco-setup-toolflow.sh
     - tapasco -v hls counter -p pynq
+    - tapasco -v -maxThreads 3 compose [counter x 3] @ 100 MHz -p pynq
 
 .tapasco_compose:
   stage: build_hw

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -439,6 +439,7 @@ tapasco_hls:
     - build_scala_tapasco_ubuntu_19_04
   script:
     - source $XILINX_VIVADO/settings64.sh
+    - apt-get -y update
     - apt -y install ./toolflow/scala/build/distributions/tapasco_2019-10_amd64.deb
     - /opt/tapasco/tapasco-init-toolflow.sh
     - source tapasco-setup-toolflow.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,7 @@ stages:
 .test_tapasco:
   stage: test_scala_toolflow
   retry: 2
+  dependencies: []
   variables:
     JAVA_VERSION: "8.0.232-zulu"
   image: ubuntu:latest
@@ -51,6 +52,7 @@ test_tapasco_java_11:
 .build_scala_tapasco_fedora:
   stage: build_scala_toolflow
   retry: 2
+  dependencies: []
   tags:
     - High
   before_script:
@@ -103,6 +105,7 @@ build_scala_tapasco_fedora_31:
 .build_scala_tapasco_ubuntu:
   stage: build_scala_toolflow
   retry: 2
+  dependencies: []
   tags:
     - High
   before_script:
@@ -137,6 +140,7 @@ build_scala_tapasco_ubuntu_19_04:
 .build_kernel_ubuntu:
   stage: build_kernel
   retry: 2
+  dependencies: []
   variables:
     MODE: "release"
   tags:
@@ -192,6 +196,7 @@ build_kernel_ubuntu_19_04_debug:
 .build_kernel_fedora:
   stage: build_kernel
   retry: 2
+  dependencies: []
   variables:
     MODE: "release"
   tags:
@@ -289,6 +294,7 @@ build_kernel_fedora_31_debug:
   retry: 2
   variables:
     MODE: "release"
+  dependencies: []
   tags:
     - Normal
   script:
@@ -429,6 +435,8 @@ tapasco_hls:
   tags:
     - CAD
   image: fedora:28
+  dependencies:
+    - build_scala_tapasco_fedora_28
   before_script:
     - dnf -y install which unzip git zip tar findutils libX11 gcc gcc-c++
     - ln -s /lib64/libtinfo.so.6 /lib64/libtinfo.so.5
@@ -436,14 +444,8 @@ tapasco_hls:
     - source $XILINX_VIVADO/settings64.sh
     - which vivado
     - which vivado_hls
-    - curl -s "https://get.sdkman.io" | bash
-    - source "/root/.sdkman/bin/sdkman-init.sh"
-    - sdk install java 11.0.5-zulu
-    - source $XILINX_VIVADO/settings64.sh
-    - source setup.sh
-    - pushd ${TAPASCO_HOME_TOOLFLOW}/scala
-    - ./gradlew installDist
-    - popd
+    - dnf -y install toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
+    - source /opt/tapasco/setup.sh
     - tapasco -v --kernelDir ${TAPASCO_HOME_TOOLFLOW}/examples/kernel-examples hls counter -p pynq
 
 .tapasco_compose:
@@ -458,6 +460,8 @@ tapasco_hls:
     - CAD
     - High
   image: fedora:28
+  dependencies:
+    - build_scala_tapasco_fedora_28
   before_script:
     - dnf -y install which unzip git zip tar findutils libX11 gcc gcc-c++ python
     - ln -s /lib64/libtinfo.so.6 /lib64/libtinfo.so.5

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,96 +11,96 @@ stages:
   - build_runtime
   - build_hw
 
-.test_tapasco:
-  stage: test_scala_toolflow
-  retry: 2
-  dependencies: []
-  variables:
-    JAVA_VERSION: "8.0.232-zulu"
-  image: ubuntu:latest
-  tags:
-    - High
-  script:
-    - apt-get -y update && apt-get -y install unzip git zip findutils curl
-    - curl -s "https://get.sdkman.io" | bash
-    - source "/root/.sdkman/bin/sdkman-init.sh"
-    - sdk install java $JAVA_VERSION
-    - ./tapasco-init.sh && source tapasco-setup.sh
-    - cd ${TAPASCO_HOME_TOOLFLOW}/scala
-    - ./gradlew test
-
-test_tapasco_java_8:
-  variables:
-    JAVA_VERSION: "8.0.232-zulu"
-  extends: .test_tapasco
-
-test_tapasco_java_9:
-  variables:
-    JAVA_VERSION: "9.0.7-zulu"
-  extends: .test_tapasco
-
-test_tapasco_java_10:
-  variables:
-    JAVA_VERSION: "10.0.2-zulu"
-  extends: .test_tapasco
-
-test_tapasco_java_11:
-  variables:
-    JAVA_VERSION: "11.0.5-zulu"
-  extends: .test_tapasco
-
-.build_scala_tapasco_fedora:
-  stage: build_scala_toolflow
-  retry: 2
-  dependencies: []
-  tags:
-    - High
-  before_script:
-    - dnf -y install which java-openjdk findutils
-  script:
-    - ./tapasco-init.sh && source tapasco-setup.sh
-    - cd ${TAPASCO_HOME_TOOLFLOW}/scala
-    - tapasco-build-toolflow
-    - ./gradlew buildRPM
-  artifacts:
-    paths:
-      - toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
-
-build_scala_tapasco_fedora_24:
-  image: fedora:24
-  extends: .build_scala_tapasco_fedora
-
-build_scala_tapasco_fedora_25:
-  image: fedora:25
-  extends: .build_scala_tapasco_fedora
-
-build_scala_tapasco_fedora_26:
-  image: fedora:26
-  extends: .build_scala_tapasco_fedora
-
-build_scala_tapasco_fedora_27:
-  image: fedora:27
-  extends: .build_scala_tapasco_fedora
-
-build_scala_tapasco_fedora_28:
-  image: fedora:28
-  extends: .build_scala_tapasco_fedora
-
-build_scala_tapasco_fedora_29:
-  image: fedora:29
-  extends: .build_scala_tapasco_fedora
-  before_script:
-    - dnf -y install which findutils java-11-openjdk
-
-build_scala_tapasco_fedora_30:
-  image: fedora:30
-  extends: .build_scala_tapasco_fedora
-  before_script:
-    - dnf -y install which findutils java-11-openjdk
-
-build_scala_tapasco_fedora_31:
-  image: fedora:31
-  extends: .build_scala_tapasco_fedora
+#.test_tapasco:
+#  stage: test_scala_toolflow
+#  retry: 2
+#  dependencies: []
+#  variables:
+#    JAVA_VERSION: "8.0.232-zulu"
+#  image: ubuntu:latest
+#  tags:
+#    - High
+#  script:
+#    - apt-get -y update && apt-get -y install unzip git zip findutils curl
+#    - curl -s "https://get.sdkman.io" | bash
+#    - source "/root/.sdkman/bin/sdkman-init.sh"
+#    - sdk install java $JAVA_VERSION
+#    - ./tapasco-init.sh && source tapasco-setup.sh
+#    - cd ${TAPASCO_HOME_TOOLFLOW}/scala
+#    - ./gradlew test
+#
+#test_tapasco_java_8:
+#  variables:
+#    JAVA_VERSION: "8.0.232-zulu"
+#  extends: .test_tapasco
+#
+#test_tapasco_java_9:
+#  variables:
+#    JAVA_VERSION: "9.0.7-zulu"
+#  extends: .test_tapasco
+#
+#test_tapasco_java_10:
+#  variables:
+#    JAVA_VERSION: "10.0.2-zulu"
+#  extends: .test_tapasco
+#
+#test_tapasco_java_11:
+#  variables:
+#    JAVA_VERSION: "11.0.5-zulu"
+#  extends: .test_tapasco
+#
+#.build_scala_tapasco_fedora:
+#  stage: build_scala_toolflow
+#  retry: 2
+#  dependencies: []
+#  tags:
+#    - High
+#  before_script:
+#    - dnf -y install which java-openjdk findutils
+#  script:
+#    - ./tapasco-init.sh && source tapasco-setup.sh
+#    - cd ${TAPASCO_HOME_TOOLFLOW}/scala
+#    - tapasco-build-toolflow
+#    - ./gradlew buildRPM
+#  artifacts:
+#    paths:
+#      - toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
+#
+#build_scala_tapasco_fedora_24:
+#  image: fedora:24
+#  extends: .build_scala_tapasco_fedora
+#
+#build_scala_tapasco_fedora_25:
+#  image: fedora:25
+#  extends: .build_scala_tapasco_fedora
+#
+#build_scala_tapasco_fedora_26:
+#  image: fedora:26
+#  extends: .build_scala_tapasco_fedora
+#
+#build_scala_tapasco_fedora_27:
+#  image: fedora:27
+#  extends: .build_scala_tapasco_fedora
+#
+#build_scala_tapasco_fedora_28:
+#  image: fedora:28
+#  extends: .build_scala_tapasco_fedora
+#
+#build_scala_tapasco_fedora_29:
+#  image: fedora:29
+#  extends: .build_scala_tapasco_fedora
+#  before_script:
+#    - dnf -y install which findutils java-11-openjdk
+#
+#build_scala_tapasco_fedora_30:
+#  image: fedora:30
+#  extends: .build_scala_tapasco_fedora
+#  before_script:
+#    - dnf -y install which findutils java-11-openjdk
+#
+#build_scala_tapasco_fedora_31:
+#  image: fedora:31
+#  extends: .build_scala_tapasco_fedora
 
 .build_scala_tapasco_ubuntu:
   stage: build_scala_toolflow
@@ -119,17 +119,17 @@ build_scala_tapasco_fedora_31:
     paths:
       - toolflow/scala/build/distributions/tapasco_2019-10_amd64.deb
 
-build_scala_tapasco_ubuntu_16_04:
-  image: ubuntu:xenial
-  extends: .build_scala_tapasco_ubuntu
-
-build_scala_tapasco_ubuntu_18_04:
-  image: ubuntu:bionic
-  extends: .build_scala_tapasco_ubuntu
-
-build_scala_tapasco_ubuntu_18_10:
-  image: ubuntu:cosmic
-  extends: .build_scala_tapasco_ubuntu
+#build_scala_tapasco_ubuntu_16_04:
+#  image: ubuntu:xenial
+#  extends: .build_scala_tapasco_ubuntu
+#
+#build_scala_tapasco_ubuntu_18_04:
+#  image: ubuntu:bionic
+#  extends: .build_scala_tapasco_ubuntu
+#
+#build_scala_tapasco_ubuntu_18_10:
+#  image: ubuntu:cosmic
+#  extends: .build_scala_tapasco_ubuntu
 
 build_scala_tapasco_ubuntu_19_04:
   image: ubuntu:disco
@@ -137,294 +137,294 @@ build_scala_tapasco_ubuntu_19_04:
 
 # build kernel module
 # as we are running in a docker instance, we cannot use tapasco-build-libs
-.build_kernel_ubuntu:
-  stage: build_kernel
-  retry: 2
-  dependencies: []
-  variables:
-    MODE: "release"
-  tags:
-    - Normal
-  script:
-    - apt-get -y update && apt-get -y install build-essential linux-headers-generic python libelf-dev
-    - ./tapasco-init.sh && source tapasco-setup.sh
-    - for d in `ls /lib/modules`; do echo "Building for linux headers in $d"; pushd runtime/kernel; make LINUX_HOME="/lib/modules/$d/build" clean && make LINUX_HOME=/lib/modules/$d/build -j 1 $MODE; popd; done
-  artifacts:
-    paths:
-      - runtime/kernel/tlkm.ko
-
-build_kernel_ubuntu_16_04:
-  image: ubuntu:xenial
-  extends: .build_kernel_ubuntu
-
-build_kernel_ubuntu_18_04:
-  image: ubuntu:bionic
-  extends: .build_kernel_ubuntu
-
-build_kernel_ubuntu_18_10:
-  image: ubuntu:cosmic
-  extends: .build_kernel_ubuntu
-
-build_kernel_ubuntu_19_04:
-  image: ubuntu:disco
-  extends: .build_kernel_ubuntu
-
-build_kernel_ubuntu_16_04_debug:
-  variables:
-    MODE: "all"
-  image: ubuntu:xenial
-  extends: .build_kernel_ubuntu
-
-build_kernel_ubuntu_18_04_debug:
-  variables:
-    MODE: "all"
-  image: ubuntu:bionic
-  extends: .build_kernel_ubuntu
-
-build_kernel_ubuntu_18_10_debug:
-  variables:
-    MODE: "all"
-  image: ubuntu:cosmic
-  extends: .build_kernel_ubuntu
-
-build_kernel_ubuntu_19_04_debug:
-  variables:
-    MODE: "all"
-  image: ubuntu:disco
-  extends: .build_kernel_ubuntu
-
-.build_kernel_fedora:
-  stage: build_kernel
-  retry: 2
-  dependencies: []
-  variables:
-    MODE: "release"
-  tags:
-    - Normal
-  script:
-    - dnf -y install kernel-devel make gcc gcc-c++ elfutils-libelf-devel
-    - ./tapasco-init.sh && source tapasco-setup.sh
-    - for d in `ls /usr/src/kernels/`; do echo "Building for linux headers in $d"; pushd runtime/kernel; make LINUX_HOME="/usr/src/kernels/$d" clean && make LINUX_HOME=/usr/src/kernels/$d -j 1 $MODE; popd; done
-  artifacts:
-    paths:
-      - runtime/kernel/tlkm.ko
-
-build_kernel_fedora_24:
-  image: fedora:24
-  extends: .build_kernel_fedora
-
-build_kernel_fedora_25:
-  image: fedora:25
-  extends: .build_kernel_fedora
-
-build_kernel_fedora_26:
-  image: fedora:26
-  extends: .build_kernel_fedora
-
-build_kernel_fedora_27:
-  image: fedora:27
-  extends: .build_kernel_fedora
-
-build_kernel_fedora_28:
-  image: fedora:28
-  extends: .build_kernel_fedora
-
-build_kernel_fedora_29:
-  image: fedora:29
-  extends: .build_kernel_fedora
-
-build_kernel_fedora_30:
-  image: fedora:30
-  extends: .build_kernel_fedora
-
-build_kernel_fedora_31:
-  image: fedora:31
-  extends: .build_kernel_fedora
-
-build_kernel_fedora_24_debug:
-  variables:
-    MODE: "all"
-  image: fedora:24
-  extends: .build_kernel_fedora
-
-build_kernel_fedora_25_debug:
-  variables:
-    MODE: "all"
-  image: fedora:25
-  extends: .build_kernel_fedora
-
-build_kernel_fedora_26_debug:
-  variables:
-    MODE: "all"
-  image: fedora:26
-  extends: .build_kernel_fedora
-
-build_kernel_fedora_27_debug:
-  variables:
-    MODE: "all"
-  image: fedora:27
-  extends: .build_kernel_fedora
-
-build_kernel_fedora_28_debug:
-  variables:
-    MODE: "all"
-  image: fedora:28
-  extends: .build_kernel_fedora
-
-build_kernel_fedora_29_debug:
-  variables:
-    MODE: "all"
-  image: fedora:29
-  extends: .build_kernel_fedora
-
-build_kernel_fedora_30_debug:
-  variables:
-    MODE: "all"
-  image: fedora:30
-  extends: .build_kernel_fedora
-
-build_kernel_fedora_31_debug:
-  variables:
-    MODE: "all"
-  image: fedora:31
-  extends: .build_kernel_fedora
-
-.build_tapasco:
-  stage: build_runtime
-  retry: 2
-  variables:
-    MODE: "release"
-  dependencies: []
-  tags:
-    - Normal
-  script:
-    - ./tapasco-init.sh && source tapasco-setup.sh
-    - tapasco-build-libs --mode=$MODE --skip_driver
-    - cd build && make package
-
-.build_tapasco_fedora:
-  before_script:
-    - dnf -y install kernel-devel make gcc gcc-c++ elfutils-libelf-devel cmake ncurses-devel python libatomic git rpm-build
-  artifacts:
-    paths:
-      - build/tapasco-*-Linux.rpm
-  extends: .build_tapasco
-
-build_tapasco_fedora_24:
-  image: fedora:24
-  extends: .build_tapasco_fedora
-
-build_tapasco_fedora_25:
-  image: fedora:25
-  extends: .build_tapasco_fedora
-
-build_tapasco_fedora_26:
-  image: fedora:26
-  extends: .build_tapasco_fedora
-
-build_tapasco_fedora_27:
-  image: fedora:27
-  extends: .build_tapasco_fedora
-
-build_tapasco_fedora_28:
-  image: fedora:28
-  extends: .build_tapasco_fedora
-
-build_tapasco_fedora_29:
-  image: fedora:29
-  extends: .build_tapasco_fedora
-
-build_tapasco_fedora_30:
-  image: fedora:30
-  extends: .build_tapasco_fedora
-
-build_tapasco_fedora_31:
-  image: fedora:31
-  extends: .build_tapasco_fedora
-
-build_tapasco_fedora_26_debug:
-  variables:
-    MODE: "debug"
-  image: fedora:26
-  extends: .build_tapasco_fedora
-
-build_tapasco_fedora_27_debug:
-  variables:
-    MODE: "debug"
-  image: fedora:27
-  extends: .build_tapasco_fedora
-
-build_tapasco_fedora_28_debug:
-  variables:
-    MODE: "debug"
-  image: fedora:28
-  extends: .build_tapasco_fedora
-
-build_tapasco_fedora_29_debug:
-  variables:
-    MODE: "debug"
-  image: fedora:29
-  extends: .build_tapasco_fedora
-
-build_tapasco_fedora_30_debug:
-  variables:
-    MODE: "debug"
-  image: fedora:30
-  extends: .build_tapasco_fedora
-
-build_tapasco_fedora_31_debug:
-  variables:
-    MODE: "debug"
-  image: fedora:31
-  extends: .build_tapasco_fedora
-
-.build_tapasco_ubuntu:
-  before_script:
-    - apt-get -y update && apt-get -y install build-essential linux-headers-generic python cmake libelf-dev libncurses-dev git rpm
-  artifacts:
-    paths:
-      - build/tapasco-*-Linux.deb
-  extends: .build_tapasco
-
-build_tapasco_ubuntu_16_04:
-  image: ubuntu:xenial
-  extends: .build_tapasco_ubuntu
-
-build_tapasco_ubuntu_18_04:
-  image: ubuntu:bionic
-  extends: .build_tapasco_ubuntu
-
-build_tapasco_ubuntu_18_10:
-  image: ubuntu:cosmic
-  extends: .build_tapasco_ubuntu
-
-build_tapasco_ubuntu_19_04:
-  image: ubuntu:disco
-  extends: .build_tapasco_ubuntu
-
-build_tapasco_ubuntu_16_04_debug:
-  variables:
-    MODE: "debug"
-  image: ubuntu:xenial
-  extends: .build_tapasco_ubuntu
-
-build_tapasco_ubuntu_18_04_debug:
-  variables:
-    MODE: "debug"
-  image: ubuntu:bionic
-  extends: .build_tapasco_ubuntu
-
-build_tapasco_ubuntu_18_10_debug:
-  variables:
-    MODE: "debug"
-  image: ubuntu:cosmic
-  extends: .build_tapasco_ubuntu
-
-build_tapasco_ubuntu_19_04_debug:
-  variables:
-    MODE: "debug"
-  image: ubuntu:disco
-  extends: .build_tapasco_ubuntu
+#.build_kernel_ubuntu:
+#  stage: build_kernel
+#  retry: 2
+#  dependencies: []
+#  variables:
+#    MODE: "release"
+#  tags:
+#    - Normal
+#  script:
+#    - apt-get -y update && apt-get -y install build-essential linux-headers-generic python libelf-dev
+#    - ./tapasco-init.sh && source tapasco-setup.sh
+#    - for d in `ls /lib/modules`; do echo "Building for linux headers in $d"; pushd runtime/kernel; make LINUX_HOME="/lib/modules/$d/build" clean && make LINUX_HOME=/lib/modules/$d/build -j 1 $MODE; popd; done
+#  artifacts:
+#    paths:
+#      - runtime/kernel/tlkm.ko
+#
+#build_kernel_ubuntu_16_04:
+#  image: ubuntu:xenial
+#  extends: .build_kernel_ubuntu
+#
+#build_kernel_ubuntu_18_04:
+#  image: ubuntu:bionic
+#  extends: .build_kernel_ubuntu
+#
+#build_kernel_ubuntu_18_10:
+#  image: ubuntu:cosmic
+#  extends: .build_kernel_ubuntu
+#
+#build_kernel_ubuntu_19_04:
+#  image: ubuntu:disco
+#  extends: .build_kernel_ubuntu
+#
+#build_kernel_ubuntu_16_04_debug:
+#  variables:
+#    MODE: "all"
+#  image: ubuntu:xenial
+#  extends: .build_kernel_ubuntu
+#
+#build_kernel_ubuntu_18_04_debug:
+#  variables:
+#    MODE: "all"
+#  image: ubuntu:bionic
+#  extends: .build_kernel_ubuntu
+#
+#build_kernel_ubuntu_18_10_debug:
+#  variables:
+#    MODE: "all"
+#  image: ubuntu:cosmic
+#  extends: .build_kernel_ubuntu
+#
+#build_kernel_ubuntu_19_04_debug:
+#  variables:
+#    MODE: "all"
+#  image: ubuntu:disco
+#  extends: .build_kernel_ubuntu
+#
+#.build_kernel_fedora:
+#  stage: build_kernel
+#  retry: 2
+#  dependencies: []
+#  variables:
+#    MODE: "release"
+#  tags:
+#    - Normal
+#  script:
+#    - dnf -y install kernel-devel make gcc gcc-c++ elfutils-libelf-devel
+#    - ./tapasco-init.sh && source tapasco-setup.sh
+#    - for d in `ls /usr/src/kernels/`; do echo "Building for linux headers in $d"; pushd runtime/kernel; make LINUX_HOME="/usr/src/kernels/$d" clean && make LINUX_HOME=/usr/src/kernels/$d -j 1 $MODE; popd; done
+#  artifacts:
+#    paths:
+#      - runtime/kernel/tlkm.ko
+#
+#build_kernel_fedora_24:
+#  image: fedora:24
+#  extends: .build_kernel_fedora
+#
+#build_kernel_fedora_25:
+#  image: fedora:25
+#  extends: .build_kernel_fedora
+#
+#build_kernel_fedora_26:
+#  image: fedora:26
+#  extends: .build_kernel_fedora
+#
+#build_kernel_fedora_27:
+#  image: fedora:27
+#  extends: .build_kernel_fedora
+#
+#build_kernel_fedora_28:
+#  image: fedora:28
+#  extends: .build_kernel_fedora
+#
+#build_kernel_fedora_29:
+#  image: fedora:29
+#  extends: .build_kernel_fedora
+#
+#build_kernel_fedora_30:
+#  image: fedora:30
+#  extends: .build_kernel_fedora
+#
+#build_kernel_fedora_31:
+#  image: fedora:31
+#  extends: .build_kernel_fedora
+#
+#build_kernel_fedora_24_debug:
+#  variables:
+#    MODE: "all"
+#  image: fedora:24
+#  extends: .build_kernel_fedora
+#
+#build_kernel_fedora_25_debug:
+#  variables:
+#    MODE: "all"
+#  image: fedora:25
+#  extends: .build_kernel_fedora
+#
+#build_kernel_fedora_26_debug:
+#  variables:
+#    MODE: "all"
+#  image: fedora:26
+#  extends: .build_kernel_fedora
+#
+#build_kernel_fedora_27_debug:
+#  variables:
+#    MODE: "all"
+#  image: fedora:27
+#  extends: .build_kernel_fedora
+#
+#build_kernel_fedora_28_debug:
+#  variables:
+#    MODE: "all"
+#  image: fedora:28
+#  extends: .build_kernel_fedora
+#
+#build_kernel_fedora_29_debug:
+#  variables:
+#    MODE: "all"
+#  image: fedora:29
+#  extends: .build_kernel_fedora
+#
+#build_kernel_fedora_30_debug:
+#  variables:
+#    MODE: "all"
+#  image: fedora:30
+#  extends: .build_kernel_fedora
+#
+#build_kernel_fedora_31_debug:
+#  variables:
+#    MODE: "all"
+#  image: fedora:31
+#  extends: .build_kernel_fedora
+#
+#.build_tapasco:
+#  stage: build_runtime
+#  retry: 2
+#  variables:
+#    MODE: "release"
+#  dependencies: []
+#  tags:
+#    - Normal
+#  script:
+#    - ./tapasco-init.sh && source tapasco-setup.sh
+#    - tapasco-build-libs --mode=$MODE --skip_driver
+#    - cd build && make package
+#
+#.build_tapasco_fedora:
+#  before_script:
+#    - dnf -y install kernel-devel make gcc gcc-c++ elfutils-libelf-devel cmake ncurses-devel python libatomic git rpm-build
+#  artifacts:
+#    paths:
+#      - build/tapasco-*-Linux.rpm
+#  extends: .build_tapasco
+#
+#build_tapasco_fedora_24:
+#  image: fedora:24
+#  extends: .build_tapasco_fedora
+#
+#build_tapasco_fedora_25:
+#  image: fedora:25
+#  extends: .build_tapasco_fedora
+#
+#build_tapasco_fedora_26:
+#  image: fedora:26
+#  extends: .build_tapasco_fedora
+#
+#build_tapasco_fedora_27:
+#  image: fedora:27
+#  extends: .build_tapasco_fedora
+#
+#build_tapasco_fedora_28:
+#  image: fedora:28
+#  extends: .build_tapasco_fedora
+#
+#build_tapasco_fedora_29:
+#  image: fedora:29
+#  extends: .build_tapasco_fedora
+#
+#build_tapasco_fedora_30:
+#  image: fedora:30
+#  extends: .build_tapasco_fedora
+#
+#build_tapasco_fedora_31:
+#  image: fedora:31
+#  extends: .build_tapasco_fedora
+#
+#build_tapasco_fedora_26_debug:
+#  variables:
+#    MODE: "debug"
+#  image: fedora:26
+#  extends: .build_tapasco_fedora
+#
+#build_tapasco_fedora_27_debug:
+#  variables:
+#    MODE: "debug"
+#  image: fedora:27
+#  extends: .build_tapasco_fedora
+#
+#build_tapasco_fedora_28_debug:
+#  variables:
+#    MODE: "debug"
+#  image: fedora:28
+#  extends: .build_tapasco_fedora
+#
+#build_tapasco_fedora_29_debug:
+#  variables:
+#    MODE: "debug"
+#  image: fedora:29
+#  extends: .build_tapasco_fedora
+#
+#build_tapasco_fedora_30_debug:
+#  variables:
+#    MODE: "debug"
+#  image: fedora:30
+#  extends: .build_tapasco_fedora
+#
+#build_tapasco_fedora_31_debug:
+#  variables:
+#    MODE: "debug"
+#  image: fedora:31
+#  extends: .build_tapasco_fedora
+#
+#.build_tapasco_ubuntu:
+#  before_script:
+#    - apt-get -y update && apt-get -y install build-essential linux-headers-generic python cmake libelf-dev libncurses-dev git rpm
+#  artifacts:
+#    paths:
+#      - build/tapasco-*-Linux.deb
+#  extends: .build_tapasco
+#
+#build_tapasco_ubuntu_16_04:
+#  image: ubuntu:xenial
+#  extends: .build_tapasco_ubuntu
+#
+#build_tapasco_ubuntu_18_04:
+#  image: ubuntu:bionic
+#  extends: .build_tapasco_ubuntu
+#
+#build_tapasco_ubuntu_18_10:
+#  image: ubuntu:cosmic
+#  extends: .build_tapasco_ubuntu
+#
+#build_tapasco_ubuntu_19_04:
+#  image: ubuntu:disco
+#  extends: .build_tapasco_ubuntu
+#
+#build_tapasco_ubuntu_16_04_debug:
+#  variables:
+#    MODE: "debug"
+#  image: ubuntu:xenial
+#  extends: .build_tapasco_ubuntu
+#
+#build_tapasco_ubuntu_18_04_debug:
+#  variables:
+#    MODE: "debug"
+#  image: ubuntu:bionic
+#  extends: .build_tapasco_ubuntu
+#
+#build_tapasco_ubuntu_18_10_debug:
+#  variables:
+#    MODE: "debug"
+#  image: ubuntu:cosmic
+#  extends: .build_tapasco_ubuntu
+#
+#build_tapasco_ubuntu_19_04_debug:
+#  variables:
+#    MODE: "debug"
+#  image: ubuntu:disco
+#  extends: .build_tapasco_ubuntu
 
 tapasco_hls:
   stage: build_hw
@@ -434,75 +434,71 @@ tapasco_hls:
     XILINXD_LICENSE_FILE: "/opt/cad/keys/xilinx"
   tags:
     - CAD
-  image: fedora:28
+  image: ubuntu:disco
   dependencies:
-    - build_scala_tapasco_fedora_28
-  before_script:
-    - dnf -y install which unzip git zip tar findutils libX11 gcc gcc-c++
-    - ln -s /lib64/libtinfo.so.6 /lib64/libtinfo.so.5
+    - build_scala_tapasco_ubuntu_19_04
   script:
     - source $XILINX_VIVADO/settings64.sh
-    - which vivado
-    - which vivado_hls
-    - dnf -y install toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
+    - dpkg -i toolflow/scala/build/distributions/tapasco_2019-10_amd64.deb
+    - apt-get -y install -f
     - /opt/tapasco/tapasco-init-toolflow.sh
     - source tapasco-setup-toolflow.sh
     - tapasco -v hls counter -p pynq
 
-.tapasco_compose:
-  stage: build_hw
-  retry: 2
-  variables:
-    VIVADO_VERSION: "2018.2"
-    XILINX_VIVADO: "/opt/cad/xilinx/vivado/Vivado/${VIVADO_VERSION}"
-    XILINXD_LICENSE_FILE: "/opt/cad/keys/xilinx"
-    PLATFORM: "pynq"
-  tags:
-    - CAD
-    - High
-  image: fedora:28
-  dependencies:
-    - build_scala_tapasco_fedora_28
-  before_script:
-    - dnf -y install which unzip git zip tar findutils libX11 gcc gcc-c++ python
-    - ln -s /lib64/libtinfo.so.6 /lib64/libtinfo.so.5
-  script:
-    - source $XILINX_VIVADO/settings64.sh
-    - which vivado
-    - which vivado_hls
-    - dnf -y install toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
-    - /opt/tapasco/tapasco-init-toolflow.sh
-    - source tapasco-setup-toolflow.sh
-    - tapasco hls counter -p $PLATFORM --skipEvaluation
-    - tapasco -v --maxThreads 3 compose [counter x 3] @ 100 MHz -p $PLATFORM
-
-tapasco_compose_17_4:
-  variables:
-    VIVADO_VERSION: "2017.4"
-  extends: .tapasco_compose
-
-tapasco_compose_18_1:
-  variables:
-    VIVADO_VERSION: "2018.1"
-  extends: .tapasco_compose
-
-tapasco_compose_18_2:
-  variables:
-    VIVADO_VERSION: "2018.2"
-  extends: .tapasco_compose
-
-tapasco_compose_18_3:
-  variables:
-    VIVADO_VERSION: "2018.3"
-  extends: .tapasco_compose
-
-tapasco_compose_19_1:
-  variables:
-    VIVADO_VERSION: "2019.1"
-  extends: .tapasco_compose
-
-tapasco_compose_pcie:
-  variables:
-    VIVADO_VERSION: "2018.3"
-    PLATFORM: "vc709"
-  extends: .tapasco_compose
+#.tapasco_compose:
+#  stage: build_hw
+#  retry: 2
+#  variables:
+#    VIVADO_VERSION: "2018.2"
+#    XILINX_VIVADO: "/opt/cad/xilinx/vivado/Vivado/${VIVADO_VERSION}"
+#    XILINXD_LICENSE_FILE: "/opt/cad/keys/xilinx"
+#    PLATFORM: "pynq"
+#  tags:
+#    - CAD
+#    - High
+#  image: fedora:28
+#  dependencies:
+#    - build_scala_tapasco_fedora_28
+#  before_script:
+#    - dnf -y install which unzip git zip tar findutils libX11 gcc gcc-c++ python
+#    - ln -s /lib64/libtinfo.so.6 /lib64/libtinfo.so.5
+#  script:
+#    - source $XILINX_VIVADO/settings64.sh
+#    - which vivado
+#    - which vivado_hls
+#    - dnf -y install toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
+#    - /opt/tapasco/tapasco-init-toolflow.sh
+#    - source tapasco-setup-toolflow.sh
+#    - tapasco hls counter -p $PLATFORM --skipEvaluation
+#    - tapasco -v --maxThreads 3 compose [counter x 3] @ 100 MHz -p $PLATFORM
+#
+#tapasco_compose_17_4:
+#  variables:
+#    VIVADO_VERSION: "2017.4"
+#  extends: .tapasco_compose
+#
+#tapasco_compose_18_1:
+#  variables:
+#    VIVADO_VERSION: "2018.1"
+#  extends: .tapasco_compose
+#
+#tapasco_compose_18_2:
+#  variables:
+#    VIVADO_VERSION: "2018.2"
+#  extends: .tapasco_compose
+#
+#tapasco_compose_18_3:
+#  variables:
+#    VIVADO_VERSION: "2018.3"
+#  extends: .tapasco_compose
+#
+#tapasco_compose_19_1:
+#  variables:
+#    VIVADO_VERSION: "2019.1"
+#  extends: .tapasco_compose
+#
+#tapasco_compose_pcie:
+#  variables:
+#    VIVADO_VERSION: "2018.3"
+#    PLATFORM: "vc709"
+#  extends: .tapasco_compose

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -114,7 +114,7 @@ stages:
     - ./tapasco-init.sh && source tapasco-setup.sh
     - cd ${TAPASCO_HOME_TOOLFLOW}/scala
     - tapasco-build-toolflow
-    - ./gradlew buildRPM
+    - ./gradlew buildDEB
   artifacts:
     paths:
       - toolflow/scala/build/distributions/tapasco_2019-10_amd64.deb

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -445,8 +445,8 @@ tapasco_hls:
     - which vivado
     - which vivado_hls
     - dnf -y install toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
-    - source /opt/tapasco/setup.sh
-    - tapasco -v --kernelDir ${TAPASCO_HOME_TOOLFLOW}/examples/kernel-examples hls counter -p pynq
+    - source /opt/tapasco/tapasco-setup.sh
+    - tapasco -v hls counter -p pynq
 
 .tapasco_compose:
   stage: build_hw

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -439,8 +439,7 @@ tapasco_hls:
     - build_scala_tapasco_ubuntu_19_04
   script:
     - source $XILINX_VIVADO/settings64.sh
-    - dpkg -i toolflow/scala/build/distributions/tapasco_2019-10_amd64.deb
-    - apt-get -y install -f
+    - apt -y install ./toolflow/scala/build/distributions/tapasco_2019-10_amd64.deb
     - /opt/tapasco/tapasco-init-toolflow.sh
     - source tapasco-setup-toolflow.sh
     - tapasco -v hls counter -p pynq

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -445,7 +445,8 @@ tapasco_hls:
     - which vivado
     - which vivado_hls
     - dnf -y install toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
-    - source /opt/tapasco/tapasco-setup.sh
+    - /opt/tapasco/tapasco-init-toolflow.sh
+    - source tapasco-setup-toolflow.sh
     - tapasco -v hls counter -p pynq
 
 .tapasco_compose:
@@ -470,7 +471,8 @@ tapasco_hls:
     - which vivado
     - which vivado_hls
     - dnf -y install toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
-    - source /opt/tapasco/tapasco-setup.sh
+    - /opt/tapasco/tapasco-init-toolflow.sh
+    - source tapasco-setup-toolflow.sh
     - tapasco hls counter -p $PLATFORM --skipEvaluation
     - tapasco -v --maxThreads 3 compose [counter x 3] @ 100 MHz -p $PLATFORM
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -436,12 +436,8 @@ tapasco_hls:
     - source $XILINX_VIVADO/settings64.sh
     - which vivado
     - which vivado_hls
-    - curl -s "https://get.sdkman.io" | bash
-    - source "/root/.sdkman/bin/sdkman-init.sh"
-    - sdk install java 11.0.5-zulu
-    - source $XILINX_VIVADO/settings64.sh
-    - ./tapasco-init.sh && source tapasco-setup.sh
-    - tapasco-build-toolflow
+    - dnf -y install toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
+    - source /opt/tapasco/tapasco-setup.sh
     - tapasco -v hls counter -p pynq
 
 .tapasco_compose:
@@ -463,13 +459,9 @@ tapasco_hls:
     - source $XILINX_VIVADO/settings64.sh
     - which vivado
     - which vivado_hls
-    - curl -s "https://get.sdkman.io" | bash
-    - source "/root/.sdkman/bin/sdkman-init.sh"
-    - sdk install java 11.0.5-zulu
-    - source $XILINX_VIVADO/settings64.sh
-    - ./tapasco-init.sh && source tapasco-setup.sh
-    - tapasco-build-toolflow
-    - tapasco hls counter -p $PLATFORM
+    - dnf -y install toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
+    - source /opt/tapasco/tapasco-setup.sh
+    - tapasco hls counter -p $PLATFORM --skipEvaluation
     - tapasco -v --maxThreads 3 compose [counter x 3] @ 100 MHz -p $PLATFORM
 
 tapasco_compose_17_4:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,96 +11,96 @@ stages:
   - build_runtime
   - build_hw
 
-#.test_tapasco:
-#  stage: test_scala_toolflow
-#  retry: 2
-#  dependencies: []
-#  variables:
-#    JAVA_VERSION: "8.0.232-zulu"
-#  image: ubuntu:latest
-#  tags:
-#    - High
-#  script:
-#    - apt-get -y update && apt-get -y install unzip git zip findutils curl
-#    - curl -s "https://get.sdkman.io" | bash
-#    - source "/root/.sdkman/bin/sdkman-init.sh"
-#    - sdk install java $JAVA_VERSION
-#    - ./tapasco-init.sh && source tapasco-setup.sh
-#    - cd ${TAPASCO_HOME_TOOLFLOW}/scala
-#    - ./gradlew test
-#
-#test_tapasco_java_8:
-#  variables:
-#    JAVA_VERSION: "8.0.232-zulu"
-#  extends: .test_tapasco
-#
-#test_tapasco_java_9:
-#  variables:
-#    JAVA_VERSION: "9.0.7-zulu"
-#  extends: .test_tapasco
-#
-#test_tapasco_java_10:
-#  variables:
-#    JAVA_VERSION: "10.0.2-zulu"
-#  extends: .test_tapasco
-#
-#test_tapasco_java_11:
-#  variables:
-#    JAVA_VERSION: "11.0.5-zulu"
-#  extends: .test_tapasco
-#
-#.build_scala_tapasco_fedora:
-#  stage: build_scala_toolflow
-#  retry: 2
-#  dependencies: []
-#  tags:
-#    - High
-#  before_script:
-#    - dnf -y install which java-openjdk findutils
-#  script:
-#    - ./tapasco-init.sh && source tapasco-setup.sh
-#    - cd ${TAPASCO_HOME_TOOLFLOW}/scala
-#    - tapasco-build-toolflow
-#    - ./gradlew buildRPM
-#  artifacts:
-#    paths:
-#      - toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
-#
-#build_scala_tapasco_fedora_24:
-#  image: fedora:24
-#  extends: .build_scala_tapasco_fedora
-#
-#build_scala_tapasco_fedora_25:
-#  image: fedora:25
-#  extends: .build_scala_tapasco_fedora
-#
-#build_scala_tapasco_fedora_26:
-#  image: fedora:26
-#  extends: .build_scala_tapasco_fedora
-#
-#build_scala_tapasco_fedora_27:
-#  image: fedora:27
-#  extends: .build_scala_tapasco_fedora
-#
-#build_scala_tapasco_fedora_28:
-#  image: fedora:28
-#  extends: .build_scala_tapasco_fedora
-#
-#build_scala_tapasco_fedora_29:
-#  image: fedora:29
-#  extends: .build_scala_tapasco_fedora
-#  before_script:
-#    - dnf -y install which findutils java-11-openjdk
-#
-#build_scala_tapasco_fedora_30:
-#  image: fedora:30
-#  extends: .build_scala_tapasco_fedora
-#  before_script:
-#    - dnf -y install which findutils java-11-openjdk
-#
-#build_scala_tapasco_fedora_31:
-#  image: fedora:31
-#  extends: .build_scala_tapasco_fedora
+.test_tapasco:
+  stage: test_scala_toolflow
+  retry: 2
+  dependencies: []
+  variables:
+    JAVA_VERSION: "8.0.232-zulu"
+  image: ubuntu:latest
+  tags:
+    - High
+  script:
+    - apt-get -y update && apt-get -y install unzip git zip findutils curl
+    - curl -s "https://get.sdkman.io" | bash
+    - source "/root/.sdkman/bin/sdkman-init.sh"
+    - sdk install java $JAVA_VERSION
+    - ./tapasco-init.sh && source tapasco-setup.sh
+    - cd ${TAPASCO_HOME_TOOLFLOW}/scala
+    - ./gradlew test
+
+test_tapasco_java_8:
+  variables:
+    JAVA_VERSION: "8.0.232-zulu"
+  extends: .test_tapasco
+
+test_tapasco_java_9:
+  variables:
+    JAVA_VERSION: "9.0.7-zulu"
+  extends: .test_tapasco
+
+test_tapasco_java_10:
+  variables:
+    JAVA_VERSION: "10.0.2-zulu"
+  extends: .test_tapasco
+
+test_tapasco_java_11:
+  variables:
+    JAVA_VERSION: "11.0.5-zulu"
+  extends: .test_tapasco
+
+.build_scala_tapasco_fedora:
+  stage: build_scala_toolflow
+  retry: 2
+  dependencies: []
+  tags:
+    - High
+  before_script:
+    - dnf -y install which java-openjdk findutils
+  script:
+    - ./tapasco-init.sh && source tapasco-setup.sh
+    - cd ${TAPASCO_HOME_TOOLFLOW}/scala
+    - tapasco-build-toolflow
+    - ./gradlew buildRPM
+  artifacts:
+    paths:
+      - toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
+
+build_scala_tapasco_fedora_24:
+  image: fedora:24
+  extends: .build_scala_tapasco_fedora
+
+build_scala_tapasco_fedora_25:
+  image: fedora:25
+  extends: .build_scala_tapasco_fedora
+
+build_scala_tapasco_fedora_26:
+  image: fedora:26
+  extends: .build_scala_tapasco_fedora
+
+build_scala_tapasco_fedora_27:
+  image: fedora:27
+  extends: .build_scala_tapasco_fedora
+
+build_scala_tapasco_fedora_28:
+  image: fedora:28
+  extends: .build_scala_tapasco_fedora
+
+build_scala_tapasco_fedora_29:
+  image: fedora:29
+  extends: .build_scala_tapasco_fedora
+  before_script:
+    - dnf -y install which findutils java-11-openjdk
+
+build_scala_tapasco_fedora_30:
+  image: fedora:30
+  extends: .build_scala_tapasco_fedora
+  before_script:
+    - dnf -y install which findutils java-11-openjdk
+
+build_scala_tapasco_fedora_31:
+  image: fedora:31
+  extends: .build_scala_tapasco_fedora
 
 .build_scala_tapasco_ubuntu:
   stage: build_scala_toolflow
@@ -119,312 +119,312 @@ stages:
     paths:
       - toolflow/scala/build/distributions/tapasco_2019-10_amd64.deb
 
-#build_scala_tapasco_ubuntu_16_04:
-#  image: ubuntu:xenial
-#  extends: .build_scala_tapasco_ubuntu
-#
-#build_scala_tapasco_ubuntu_18_04:
-#  image: ubuntu:bionic
-#  extends: .build_scala_tapasco_ubuntu
-#
-#build_scala_tapasco_ubuntu_18_10:
-#  image: ubuntu:cosmic
-#  extends: .build_scala_tapasco_ubuntu
+build_scala_tapasco_ubuntu_16_04:
+  image: ubuntu:xenial
+  extends: .build_scala_tapasco_ubuntu
+
+build_scala_tapasco_ubuntu_18_04:
+  image: ubuntu:bionic
+  extends: .build_scala_tapasco_ubuntu
+
+build_scala_tapasco_ubuntu_18_10:
+  image: ubuntu:cosmic
+  extends: .build_scala_tapasco_ubuntu
 
 build_scala_tapasco_ubuntu_19_04:
   image: ubuntu:disco
   extends: .build_scala_tapasco_ubuntu
 
-# build kernel module
-# as we are running in a docker instance, we cannot use tapasco-build-libs
-#.build_kernel_ubuntu:
-#  stage: build_kernel
-#  retry: 2
-#  dependencies: []
-#  variables:
-#    MODE: "release"
-#  tags:
-#    - Normal
-#  script:
-#    - apt-get -y update && apt-get -y install build-essential linux-headers-generic python libelf-dev
-#    - ./tapasco-init.sh && source tapasco-setup.sh
-#    - for d in `ls /lib/modules`; do echo "Building for linux headers in $d"; pushd runtime/kernel; make LINUX_HOME="/lib/modules/$d/build" clean && make LINUX_HOME=/lib/modules/$d/build -j 1 $MODE; popd; done
-#  artifacts:
-#    paths:
-#      - runtime/kernel/tlkm.ko
-#
-#build_kernel_ubuntu_16_04:
-#  image: ubuntu:xenial
-#  extends: .build_kernel_ubuntu
-#
-#build_kernel_ubuntu_18_04:
-#  image: ubuntu:bionic
-#  extends: .build_kernel_ubuntu
-#
-#build_kernel_ubuntu_18_10:
-#  image: ubuntu:cosmic
-#  extends: .build_kernel_ubuntu
-#
-#build_kernel_ubuntu_19_04:
-#  image: ubuntu:disco
-#  extends: .build_kernel_ubuntu
-#
-#build_kernel_ubuntu_16_04_debug:
-#  variables:
-#    MODE: "all"
-#  image: ubuntu:xenial
-#  extends: .build_kernel_ubuntu
-#
-#build_kernel_ubuntu_18_04_debug:
-#  variables:
-#    MODE: "all"
-#  image: ubuntu:bionic
-#  extends: .build_kernel_ubuntu
-#
-#build_kernel_ubuntu_18_10_debug:
-#  variables:
-#    MODE: "all"
-#  image: ubuntu:cosmic
-#  extends: .build_kernel_ubuntu
-#
-#build_kernel_ubuntu_19_04_debug:
-#  variables:
-#    MODE: "all"
-#  image: ubuntu:disco
-#  extends: .build_kernel_ubuntu
-#
-#.build_kernel_fedora:
-#  stage: build_kernel
-#  retry: 2
-#  dependencies: []
-#  variables:
-#    MODE: "release"
-#  tags:
-#    - Normal
-#  script:
-#    - dnf -y install kernel-devel make gcc gcc-c++ elfutils-libelf-devel
-#    - ./tapasco-init.sh && source tapasco-setup.sh
-#    - for d in `ls /usr/src/kernels/`; do echo "Building for linux headers in $d"; pushd runtime/kernel; make LINUX_HOME="/usr/src/kernels/$d" clean && make LINUX_HOME=/usr/src/kernels/$d -j 1 $MODE; popd; done
-#  artifacts:
-#    paths:
-#      - runtime/kernel/tlkm.ko
-#
-#build_kernel_fedora_24:
-#  image: fedora:24
-#  extends: .build_kernel_fedora
-#
-#build_kernel_fedora_25:
-#  image: fedora:25
-#  extends: .build_kernel_fedora
-#
-#build_kernel_fedora_26:
-#  image: fedora:26
-#  extends: .build_kernel_fedora
-#
-#build_kernel_fedora_27:
-#  image: fedora:27
-#  extends: .build_kernel_fedora
-#
-#build_kernel_fedora_28:
-#  image: fedora:28
-#  extends: .build_kernel_fedora
-#
-#build_kernel_fedora_29:
-#  image: fedora:29
-#  extends: .build_kernel_fedora
-#
-#build_kernel_fedora_30:
-#  image: fedora:30
-#  extends: .build_kernel_fedora
-#
-#build_kernel_fedora_31:
-#  image: fedora:31
-#  extends: .build_kernel_fedora
-#
-#build_kernel_fedora_24_debug:
-#  variables:
-#    MODE: "all"
-#  image: fedora:24
-#  extends: .build_kernel_fedora
-#
-#build_kernel_fedora_25_debug:
-#  variables:
-#    MODE: "all"
-#  image: fedora:25
-#  extends: .build_kernel_fedora
-#
-#build_kernel_fedora_26_debug:
-#  variables:
-#    MODE: "all"
-#  image: fedora:26
-#  extends: .build_kernel_fedora
-#
-#build_kernel_fedora_27_debug:
-#  variables:
-#    MODE: "all"
-#  image: fedora:27
-#  extends: .build_kernel_fedora
-#
-#build_kernel_fedora_28_debug:
-#  variables:
-#    MODE: "all"
-#  image: fedora:28
-#  extends: .build_kernel_fedora
-#
-#build_kernel_fedora_29_debug:
-#  variables:
-#    MODE: "all"
-#  image: fedora:29
-#  extends: .build_kernel_fedora
-#
-#build_kernel_fedora_30_debug:
-#  variables:
-#    MODE: "all"
-#  image: fedora:30
-#  extends: .build_kernel_fedora
-#
-#build_kernel_fedora_31_debug:
-#  variables:
-#    MODE: "all"
-#  image: fedora:31
-#  extends: .build_kernel_fedora
-#
-#.build_tapasco:
-#  stage: build_runtime
-#  retry: 2
-#  variables:
-#    MODE: "release"
-#  dependencies: []
-#  tags:
-#    - Normal
-#  script:
-#    - ./tapasco-init.sh && source tapasco-setup.sh
-#    - tapasco-build-libs --mode=$MODE --skip_driver
-#    - cd build && make package
-#
-#.build_tapasco_fedora:
-#  before_script:
-#    - dnf -y install kernel-devel make gcc gcc-c++ elfutils-libelf-devel cmake ncurses-devel python libatomic git rpm-build
-#  artifacts:
-#    paths:
-#      - build/tapasco-*-Linux.rpm
-#  extends: .build_tapasco
-#
-#build_tapasco_fedora_24:
-#  image: fedora:24
-#  extends: .build_tapasco_fedora
-#
-#build_tapasco_fedora_25:
-#  image: fedora:25
-#  extends: .build_tapasco_fedora
-#
-#build_tapasco_fedora_26:
-#  image: fedora:26
-#  extends: .build_tapasco_fedora
-#
-#build_tapasco_fedora_27:
-#  image: fedora:27
-#  extends: .build_tapasco_fedora
-#
-#build_tapasco_fedora_28:
-#  image: fedora:28
-#  extends: .build_tapasco_fedora
-#
-#build_tapasco_fedora_29:
-#  image: fedora:29
-#  extends: .build_tapasco_fedora
-#
-#build_tapasco_fedora_30:
-#  image: fedora:30
-#  extends: .build_tapasco_fedora
-#
-#build_tapasco_fedora_31:
-#  image: fedora:31
-#  extends: .build_tapasco_fedora
-#
-#build_tapasco_fedora_26_debug:
-#  variables:
-#    MODE: "debug"
-#  image: fedora:26
-#  extends: .build_tapasco_fedora
-#
-#build_tapasco_fedora_27_debug:
-#  variables:
-#    MODE: "debug"
-#  image: fedora:27
-#  extends: .build_tapasco_fedora
-#
-#build_tapasco_fedora_28_debug:
-#  variables:
-#    MODE: "debug"
-#  image: fedora:28
-#  extends: .build_tapasco_fedora
-#
-#build_tapasco_fedora_29_debug:
-#  variables:
-#    MODE: "debug"
-#  image: fedora:29
-#  extends: .build_tapasco_fedora
-#
-#build_tapasco_fedora_30_debug:
-#  variables:
-#    MODE: "debug"
-#  image: fedora:30
-#  extends: .build_tapasco_fedora
-#
-#build_tapasco_fedora_31_debug:
-#  variables:
-#    MODE: "debug"
-#  image: fedora:31
-#  extends: .build_tapasco_fedora
-#
-#.build_tapasco_ubuntu:
-#  before_script:
-#    - apt-get -y update && apt-get -y install build-essential linux-headers-generic python cmake libelf-dev libncurses-dev git rpm
-#  artifacts:
-#    paths:
-#      - build/tapasco-*-Linux.deb
-#  extends: .build_tapasco
-#
-#build_tapasco_ubuntu_16_04:
-#  image: ubuntu:xenial
-#  extends: .build_tapasco_ubuntu
-#
-#build_tapasco_ubuntu_18_04:
-#  image: ubuntu:bionic
-#  extends: .build_tapasco_ubuntu
-#
-#build_tapasco_ubuntu_18_10:
-#  image: ubuntu:cosmic
-#  extends: .build_tapasco_ubuntu
-#
-#build_tapasco_ubuntu_19_04:
-#  image: ubuntu:disco
-#  extends: .build_tapasco_ubuntu
-#
-#build_tapasco_ubuntu_16_04_debug:
-#  variables:
-#    MODE: "debug"
-#  image: ubuntu:xenial
-#  extends: .build_tapasco_ubuntu
-#
-#build_tapasco_ubuntu_18_04_debug:
-#  variables:
-#    MODE: "debug"
-#  image: ubuntu:bionic
-#  extends: .build_tapasco_ubuntu
-#
-#build_tapasco_ubuntu_18_10_debug:
-#  variables:
-#    MODE: "debug"
-#  image: ubuntu:cosmic
-#  extends: .build_tapasco_ubuntu
-#
-#build_tapasco_ubuntu_19_04_debug:
-#  variables:
-#    MODE: "debug"
-#  image: ubuntu:disco
-#  extends: .build_tapasco_ubuntu
+ build kernel module
+ as we are running in a docker instance, we cannot use tapasco-build-libs
+.build_kernel_ubuntu:
+  stage: build_kernel
+  retry: 2
+  dependencies: []
+  variables:
+    MODE: "release"
+  tags:
+    - Normal
+  script:
+    - apt-get -y update && apt-get -y install build-essential linux-headers-generic python libelf-dev
+    - ./tapasco-init.sh && source tapasco-setup.sh
+    - for d in `ls /lib/modules`; do echo "Building for linux headers in $d"; pushd runtime/kernel; make LINUX_HOME="/lib/modules/$d/build" clean && make LINUX_HOME=/lib/modules/$d/build -j 1 $MODE; popd; done
+  artifacts:
+    paths:
+      - runtime/kernel/tlkm.ko
+
+build_kernel_ubuntu_16_04:
+  image: ubuntu:xenial
+  extends: .build_kernel_ubuntu
+
+build_kernel_ubuntu_18_04:
+  image: ubuntu:bionic
+  extends: .build_kernel_ubuntu
+
+build_kernel_ubuntu_18_10:
+  image: ubuntu:cosmic
+  extends: .build_kernel_ubuntu
+
+build_kernel_ubuntu_19_04:
+  image: ubuntu:disco
+  extends: .build_kernel_ubuntu
+
+build_kernel_ubuntu_16_04_debug:
+  variables:
+    MODE: "all"
+  image: ubuntu:xenial
+  extends: .build_kernel_ubuntu
+
+build_kernel_ubuntu_18_04_debug:
+  variables:
+    MODE: "all"
+  image: ubuntu:bionic
+  extends: .build_kernel_ubuntu
+
+build_kernel_ubuntu_18_10_debug:
+  variables:
+    MODE: "all"
+  image: ubuntu:cosmic
+  extends: .build_kernel_ubuntu
+
+build_kernel_ubuntu_19_04_debug:
+  variables:
+    MODE: "all"
+  image: ubuntu:disco
+  extends: .build_kernel_ubuntu
+
+.build_kernel_fedora:
+  stage: build_kernel
+  retry: 2
+  dependencies: []
+  variables:
+    MODE: "release"
+  tags:
+    - Normal
+  script:
+    - dnf -y install kernel-devel make gcc gcc-c++ elfutils-libelf-devel
+    - ./tapasco-init.sh && source tapasco-setup.sh
+    - for d in `ls /usr/src/kernels/`; do echo "Building for linux headers in $d"; pushd runtime/kernel; make LINUX_HOME="/usr/src/kernels/$d" clean && make LINUX_HOME=/usr/src/kernels/$d -j 1 $MODE; popd; done
+  artifacts:
+    paths:
+      - runtime/kernel/tlkm.ko
+
+build_kernel_fedora_24:
+  image: fedora:24
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_25:
+  image: fedora:25
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_26:
+  image: fedora:26
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_27:
+  image: fedora:27
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_28:
+  image: fedora:28
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_29:
+  image: fedora:29
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_30:
+  image: fedora:30
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_31:
+  image: fedora:31
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_24_debug:
+  variables:
+    MODE: "all"
+  image: fedora:24
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_25_debug:
+  variables:
+    MODE: "all"
+  image: fedora:25
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_26_debug:
+  variables:
+    MODE: "all"
+  image: fedora:26
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_27_debug:
+  variables:
+    MODE: "all"
+  image: fedora:27
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_28_debug:
+  variables:
+    MODE: "all"
+  image: fedora:28
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_29_debug:
+  variables:
+    MODE: "all"
+  image: fedora:29
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_30_debug:
+  variables:
+    MODE: "all"
+  image: fedora:30
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_31_debug:
+  variables:
+    MODE: "all"
+  image: fedora:31
+  extends: .build_kernel_fedora
+
+.build_tapasco:
+  stage: build_runtime
+  retry: 2
+  variables:
+    MODE: "release"
+  dependencies: []
+  tags:
+    - Normal
+  script:
+    - ./tapasco-init.sh && source tapasco-setup.sh
+    - tapasco-build-libs --mode=$MODE --skip_driver
+    - cd build && make package
+
+.build_tapasco_fedora:
+  before_script:
+    - dnf -y install kernel-devel make gcc gcc-c++ elfutils-libelf-devel cmake ncurses-devel python libatomic git rpm-build
+  artifacts:
+    paths:
+      - build/tapasco-*-Linux.rpm
+  extends: .build_tapasco
+
+build_tapasco_fedora_24:
+  image: fedora:24
+  extends: .build_tapasco_fedora
+
+build_tapasco_fedora_25:
+  image: fedora:25
+  extends: .build_tapasco_fedora
+
+build_tapasco_fedora_26:
+  image: fedora:26
+  extends: .build_tapasco_fedora
+
+build_tapasco_fedora_27:
+  image: fedora:27
+  extends: .build_tapasco_fedora
+
+build_tapasco_fedora_28:
+  image: fedora:28
+  extends: .build_tapasco_fedora
+
+build_tapasco_fedora_29:
+  image: fedora:29
+  extends: .build_tapasco_fedora
+
+build_tapasco_fedora_30:
+  image: fedora:30
+  extends: .build_tapasco_fedora
+
+build_tapasco_fedora_31:
+  image: fedora:31
+  extends: .build_tapasco_fedora
+
+build_tapasco_fedora_26_debug:
+  variables:
+    MODE: "debug"
+  image: fedora:26
+  extends: .build_tapasco_fedora
+
+build_tapasco_fedora_27_debug:
+  variables:
+    MODE: "debug"
+  image: fedora:27
+  extends: .build_tapasco_fedora
+
+build_tapasco_fedora_28_debug:
+  variables:
+    MODE: "debug"
+  image: fedora:28
+  extends: .build_tapasco_fedora
+
+build_tapasco_fedora_29_debug:
+  variables:
+    MODE: "debug"
+  image: fedora:29
+  extends: .build_tapasco_fedora
+
+build_tapasco_fedora_30_debug:
+  variables:
+    MODE: "debug"
+  image: fedora:30
+  extends: .build_tapasco_fedora
+
+build_tapasco_fedora_31_debug:
+  variables:
+    MODE: "debug"
+  image: fedora:31
+  extends: .build_tapasco_fedora
+
+.build_tapasco_ubuntu:
+  before_script:
+    - apt-get -y update && apt-get -y install build-essential linux-headers-generic python cmake libelf-dev libncurses-dev git rpm
+  artifacts:
+    paths:
+      - build/tapasco-*-Linux.deb
+  extends: .build_tapasco
+
+build_tapasco_ubuntu_16_04:
+  image: ubuntu:xenial
+  extends: .build_tapasco_ubuntu
+
+build_tapasco_ubuntu_18_04:
+  image: ubuntu:bionic
+  extends: .build_tapasco_ubuntu
+
+build_tapasco_ubuntu_18_10:
+  image: ubuntu:cosmic
+  extends: .build_tapasco_ubuntu
+
+build_tapasco_ubuntu_19_04:
+  image: ubuntu:disco
+  extends: .build_tapasco_ubuntu
+
+build_tapasco_ubuntu_16_04_debug:
+  variables:
+    MODE: "debug"
+  image: ubuntu:xenial
+  extends: .build_tapasco_ubuntu
+
+build_tapasco_ubuntu_18_04_debug:
+  variables:
+    MODE: "debug"
+  image: ubuntu:bionic
+  extends: .build_tapasco_ubuntu
+
+build_tapasco_ubuntu_18_10_debug:
+  variables:
+    MODE: "debug"
+  image: ubuntu:cosmic
+  extends: .build_tapasco_ubuntu
+
+build_tapasco_ubuntu_19_04_debug:
+  variables:
+    MODE: "debug"
+  image: ubuntu:disco
+  extends: .build_tapasco_ubuntu
 
 tapasco_hls:
   stage: build_hw
@@ -446,60 +446,60 @@ tapasco_hls:
     - source tapasco-setup-toolflow.sh
     - tapasco -v hls counter -p pynq
 
-#.tapasco_compose:
-#  stage: build_hw
-#  retry: 2
-#  variables:
-#    VIVADO_VERSION: "2019.1"
-#    XILINX_VIVADO: "/opt/cad/xilinx/vivado/Vivado/${VIVADO_VERSION}"
-#    XILINXD_LICENSE_FILE: "/opt/cad/keys/xilinx"
-#    PLATFORM: "pynq"
-#  tags:
-#    - CAD
-#    - High
-#  image: fedora:28
-#  dependencies:
-#    - build_scala_tapasco_fedora_28
-#  before_script:
-#    - dnf -y install which unzip git zip tar findutils libX11 gcc gcc-c++ python
-#    - ln -s /lib64/libtinfo.so.6 /lib64/libtinfo.so.5
-#  script:
-#    - source $XILINX_VIVADO/settings64.sh
-#    - which vivado
-#    - which vivado_hls
-#    - dnf -y install toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
-#    - /opt/tapasco/tapasco-init-toolflow.sh
-#    - source tapasco-setup-toolflow.sh
-#    - tapasco hls counter -p $PLATFORM --skipEvaluation
-#    - tapasco -v --maxThreads 3 compose [counter x 3] @ 100 MHz -p $PLATFORM
-#
-#tapasco_compose_17_4:
-#  variables:
-#    VIVADO_VERSION: "2017.4"
-#  extends: .tapasco_compose
-#
-#tapasco_compose_18_1:
-#  variables:
-#    VIVADO_VERSION: "2018.1"
-#  extends: .tapasco_compose
-#
-#tapasco_compose_18_2:
-#  variables:
-#    VIVADO_VERSION: "2018.2"
-#  extends: .tapasco_compose
-#
-#tapasco_compose_18_3:
-#  variables:
-#    VIVADO_VERSION: "2018.3"
-#  extends: .tapasco_compose
-#
-#tapasco_compose_19_1:
-#  variables:
-#    VIVADO_VERSION: "2019.1"
-#  extends: .tapasco_compose
-#
-#tapasco_compose_pcie:
-#  variables:
-#    VIVADO_VERSION: "2018.3"
-#    PLATFORM: "vc709"
-#  extends: .tapasco_compose
+.tapasco_compose:
+  stage: build_hw
+  retry: 2
+  variables:
+    VIVADO_VERSION: "2019.1"
+    XILINX_VIVADO: "/opt/cad/xilinx/vivado/Vivado/${VIVADO_VERSION}"
+    XILINXD_LICENSE_FILE: "/opt/cad/keys/xilinx"
+    PLATFORM: "pynq"
+  tags:
+    - CAD
+    - High
+  image: fedora:28
+  dependencies:
+    - build_scala_tapasco_fedora_28
+  before_script:
+    - dnf -y install which unzip git zip tar findutils libX11 gcc gcc-c++ python
+    - ln -s /lib64/libtinfo.so.6 /lib64/libtinfo.so.5
+  script:
+    - source $XILINX_VIVADO/settings64.sh
+    - which vivado
+    - which vivado_hls
+    - dnf -y install toolflow/scala/build/distributions/tapasco-2019-10.x86_64.rpm
+    - /opt/tapasco/tapasco-init-toolflow.sh
+    - source tapasco-setup-toolflow.sh
+    - tapasco hls counter -p $PLATFORM --skipEvaluation
+    - tapasco -v --maxThreads 3 compose [counter x 3] @ 100 MHz -p $PLATFORM
+
+tapasco_compose_17_4:
+  variables:
+    VIVADO_VERSION: "2017.4"
+  extends: .tapasco_compose
+
+tapasco_compose_18_1:
+  variables:
+    VIVADO_VERSION: "2018.1"
+  extends: .tapasco_compose
+
+tapasco_compose_18_2:
+  variables:
+    VIVADO_VERSION: "2018.2"
+  extends: .tapasco_compose
+
+tapasco_compose_18_3:
+  variables:
+    VIVADO_VERSION: "2018.3"
+  extends: .tapasco_compose
+
+tapasco_compose_19_1:
+  variables:
+    VIVADO_VERSION: "2019.1"
+  extends: .tapasco_compose
+
+tapasco_compose_pcie:
+  variables:
+    VIVADO_VERSION: "2018.3"
+    PLATFORM: "vc709"
+  extends: .tapasco_compose

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -440,7 +440,7 @@ tapasco_hls:
   script:
     - source $XILINX_VIVADO/settings64.sh
     - apt-get -y update
-    - apt-get -y install libtinfo5
+    - apt-get -y install libtinfo5 build-essential
     - apt -y install ./toolflow/scala/build/distributions/tapasco_2019-10_amd64.deb
     - /opt/tapasco/tapasco-init-toolflow.sh
     - source tapasco-setup-toolflow.sh

--- a/toolflow/os-package/tapasco-init-toolflow.sh
+++ b/toolflow/os-package/tapasco-init-toolflow.sh
@@ -4,7 +4,7 @@ else
     echo "Creating tapasco-setup-toolflow.sh"
 
     export TAPASCO_HOME=/opt/tapasco
-    export TAPASCO_HOME_TOOLFLOW=${TAPASCO_HOME}/toolflow
+    export TAPASCO_HOME_TOOLFLOW=${TAPASCO_HOME}
     export TAPASCO_HOME_TCL=${TAPASCO_HOME_TOOLFLOW}/vivado
     export TAPASCO_HOME_RUNTIME=${TAPASCO_HOME}/runtime
     export TAPASCO_WORK_DIR=$PWD

--- a/toolflow/os-package/tapasco-init-toolflow.sh
+++ b/toolflow/os-package/tapasco-init-toolflow.sh
@@ -11,12 +11,12 @@ else
 
     echo "export TAPASCO_HOME=${TAPASCO_HOME}" > tapasco-setup-toolflow.sh
     echo "echo Using TaPaSCo from ${TAPASCO_HOME}" >> tapasco-setup-toolflow.sh
-    echo "export TAPASCO_HOME_TOOLFLOW=${TAPASCO_HOME}/toolflow" >> tapasco-setup-toolflow.sh
+    echo "export TAPASCO_HOME_TOOLFLOW=${TAPASCO_HOME}" >> tapasco-setup-toolflow.sh
     echo "export TAPASCO_HOME_TCL=${TAPASCO_HOME_TOOLFLOW}/vivado" >> tapasco-setup-toolflow.sh
     echo "export TAPASCO_HOME_RUNTIME=${TAPASCO_HOME}/runtime" >> tapasco-setup-toolflow.sh
     echo "export TAPASCO_WORK_DIR=$PWD" >> tapasco-setup-toolflow.sh
 
-    echo "export PATH=\"${TAPASCO_HOME_TOOLFLOW}/bin:${TAPASCO_HOME_RUNTIME}/bin:${TAPASCO_WORK_DIR}/build/install/usr/local/bin/:${TAPASCO_HOME_TOOLFLOW}/scala/build/install/tapasco/bin:\$PATH\"" >> tapasco-setup-toolflow.sh
+    echo "export PATH=\"${TAPASCO_HOME_TOOLFLOW}/bin:\$PATH\"" >> tapasco-setup-toolflow.sh
     echo "export MANPATH=\$MANPATH:$TAPASCO_HOME/man" >> tapasco-setup-toolflow.sh
     echo "export MYVIVADO=\$MYVIVADO:${TAPASCO_HOME_TCL}/common" >> tapasco-setup-toolflow.sh
     echo "export XILINX_PATH=\$XILINX_PATH:${TAPASCO_HOME_TCL}/common" >> tapasco-setup-toolflow.sh


### PR DESCRIPTION
 - Adds restrictions on dependencies to avoid download artifacts when not used
 - Uses fedora rpm on tapasco_compose_* stages
 - Fixes os-package install scripts
 - Closes #143 