### PR TITLE
Fixes multiple problems regarding 32bit builds

### DIFF
--- a/runtime/arch/common/src/tapasco_local_mem.c
+++ b/runtime/arch/common/src/tapasco_local_mem.c
@@ -108,8 +108,9 @@ tapasco_res_t tapasco_local_mem_alloc(tapasco_local_mem_t *lmem,
 }
 
 void tapasco_local_mem_dealloc(tapasco_local_mem_t *lmem,
-                               tapasco_slot_id_t slot_id, size_t sz,
-                               tapasco_handle_t h) {
+                               tapasco_slot_id_t slot_id,
+                               tapasco_handle_t h,
+                               size_t sz) {
   tapasco_slot_id_t slot_id_local =
       tapasco_local_mem_get_slot(lmem->devctx, slot_id);
   DEVLOG(lmem->dev_id, LALL_MEM,

--- a/runtime/arch/common/src/tapasco_memory.c
+++ b/runtime/arch/common/src/tapasco_memory.c
@@ -72,8 +72,8 @@ tapasco_res_t tapasco_device_copy_to_local(
 
   LOG(LALL_MEM,
       "copying %zd bytes locally to " PRIhandle " of slot_id #" PRIslot
-      " from 0x%llx",
-      len, dst, lmem_slot_id, (uint64_t)a);
+      " from 0x%zx",
+      len, dst, lmem_slot_id, (size_t)a);
 
   uint8_t *src_ptr = (uint8_t *)src;
   size_t chunk_size = 0;
@@ -111,8 +111,8 @@ tapasco_res_t tapasco_device_copy_from_local(
   volatile uint8_t *a = (volatile uint8_t *)ptr_a_calc;
   LOG(LALL_MEM,
       "copying %zd bytes locally from " PRIhandle " of slot_id #" PRIslot
-      " from 0x%llx",
-      len, dst, lmem_slot_id, (uint64_t)a);
+      " from 0x%zx",
+      len, dst, lmem_slot_id, (size_t)a);
 
   uint8_t *dst_ptr = (uint8_t *)dst;
   size_t chunk_size = 0;

--- a/runtime/arch/include/tapasco_types.h
+++ b/runtime/arch/include/tapasco_types.h
@@ -62,7 +62,7 @@ typedef ul tapasco_job_id_t;
 #define PRIjob "%lu"
 
 /** Device memory location handle (opaque). **/
-typedef ul tapasco_handle_t;
+typedef uint64_t tapasco_handle_t;
 #define PRIhandle "%#08lx"
 
 /** default value for no flags **/

--- a/runtime/examples/tapasco-benchmark/TransferSpeed.hpp
+++ b/runtime/examples/tapasco-benchmark/TransferSpeed.hpp
@@ -175,12 +175,8 @@ private:
   void transfer(volatile atomic<bool> &stop, size_t const chunk_sz,
                 long opmask) {
     std::vector<uint8_t> data_read(chunk_sz);
-    // for (auto &i : data_read)
-    //  i = rand();
 
     std::vector<uint8_t> data_write(chunk_sz);
-    // for (auto &i : data_write)
-    //  i = rand();
 
     std::thread readthread(&TransferSpeed::do_read, this, std::ref(stop),
                            chunk_sz, opmask, data_read.data());

--- a/runtime/examples/tapasco-benchmark/TransferSpeed.hpp
+++ b/runtime/examples/tapasco-benchmark/TransferSpeed.hpp
@@ -42,12 +42,33 @@ public:
 
     bytes = 0;
 
-    auto tstart{high_resolution_clock::now()};
-    duration<double> d{high_resolution_clock::now() - tstart};
+    read_ready = false;
+    write_ready = false;
+    main_ready = false;
+
     future<void> f{
         async(launch::async, [&]() { transfer(stop, chunk_sz, opmask); })};
+
+    while (!stop.load() && !(read_ready.load() && write_ready.load())) {
+      usleep(10000);
+    }
+
+    main_ready = true;
+
+    if (stop.load()) {
+      std::cout << "Failed to initalize chunk size of " << cs / 1024.0
+                << "MiB. Most likely too large." << std::endl;
+      return 0;
+    }
+
+    auto tstart{high_resolution_clock::now()};
+    duration<double> d{high_resolution_clock::now() - tstart};
     double delta = 0.0;
     do {
+      b = bytes.load() / (1024.0 * 1024.0);
+      d = high_resolution_clock::now() - tstart;
+      delta = fabs(cavg.update(b / d.count()));
+
       std::ios_base::fmtflags coutf(cout.flags());
       if (cs <= 1024) {
         std::cout << "\rChunk size: " << std::dec << std::fixed << std::setw(10)
@@ -63,9 +84,6 @@ public:
                 << std::setprecision(3) << cavg() << " MiB/s" << std::flush;
       cout.flags(coutf);
       usleep(10000);
-      b = bytes.load() / (1024.0 * 1024.0);
-      d = high_resolution_clock::now() - tstart;
-      delta = fabs(cavg.update(b / d.count()));
     } while (((!fast && delta > 0.1) || cavg.size() < 100 ||
               (bytes.load() <= 2 * chunk_sz)));
 
@@ -95,14 +113,24 @@ public:
 private:
   tapasco_res_t do_read(volatile atomic<bool> &stop, size_t const chunk_sz,
                         long opmask, uint8_t *data) {
-    if (!(opmask & OP_COPYFROM))
+    if (!(opmask & OP_COPYFROM)) {
+      read_ready = true;
       return TAPASCO_SUCCESS;
+    }
     tapasco_handle_t h;
     tapasco_res_t r{
         tapasco.alloc(h, chunk_sz, TAPASCO_DEVICE_ALLOC_FLAGS_NONE)};
+
+    read_ready = true;
+
     if (r != TAPASCO_SUCCESS) {
+      stop = true;
       return r;
     }
+
+    while (!main_ready.load())
+      usleep(10);
+
     while (!stop.load()) {
       r = tapasco.copy_from(h, data, chunk_sz, TAPASCO_DEVICE_COPY_BLOCKING);
       if (r != TAPASCO_SUCCESS) {
@@ -117,14 +145,21 @@ private:
 
   tapasco_res_t do_write(volatile atomic<bool> &stop, size_t const chunk_sz,
                          long opmask, uint8_t *data) {
-    if (!(opmask & OP_COPYTO))
+    if (!(opmask & OP_COPYTO)) {
+      write_ready = true;
       return TAPASCO_SUCCESS;
+    }
     tapasco_handle_t h;
     tapasco_res_t r{
         tapasco.alloc(h, chunk_sz, TAPASCO_DEVICE_ALLOC_FLAGS_NONE)};
+    write_ready = true;
+
     if (r != TAPASCO_SUCCESS) {
+      stop = true;
       return r;
     }
+    while (!main_ready.load())
+      usleep(10);
     while (!stop.load()) {
       r = tapasco.copy_to(data, h, chunk_sz, TAPASCO_DEVICE_COPY_BLOCKING);
       if (r != TAPASCO_SUCCESS) {
@@ -140,12 +175,12 @@ private:
   void transfer(volatile atomic<bool> &stop, size_t const chunk_sz,
                 long opmask) {
     std::vector<uint8_t> data_read(chunk_sz);
-    for (auto &i : data_read)
-      i = rand();
+    // for (auto &i : data_read)
+    //  i = rand();
 
     std::vector<uint8_t> data_write(chunk_sz);
-    for (auto &i : data_write)
-      i = rand();
+    // for (auto &i : data_write)
+    //  i = rand();
 
     std::thread readthread(&TransferSpeed::do_read, this, std::ref(stop),
                            chunk_sz, opmask, data_read.data());
@@ -164,6 +199,9 @@ private:
   }
 
   atomic<uint64_t> bytes{0};
+  atomic<bool> read_ready{false};
+  atomic<bool> write_ready{false};
+  atomic<bool> main_ready{false};
   Tapasco &tapasco;
   bool fast;
 };

--- a/runtime/platform/common/src/platform_devctx.c
+++ b/runtime/platform/common/src/platform_devctx.c
@@ -23,7 +23,7 @@
 
 static platform_res_t platform_specific_init(platform_devctx_t *devctx) {
   if (!strncmp(PCIE_CLS_NAME, devctx->dev_info.name, TLKM_DEVNAME_SZ)) {
-    return default_init(devctx, PCIE_MEM_SZ);
+    return default_init(devctx, (platform_mem_addr_t)PCIE_MEM_SZ);
   } else if (!strncmp(ZYNQ_CLS_NAME, devctx->dev_info.name, TLKM_DEVNAME_SZ)) {
     return default_init(devctx, 0);
   } else {

--- a/runtime/platform/common/src/platform_device_operations.c
+++ b/runtime/platform/common/src/platform_device_operations.c
@@ -362,7 +362,7 @@ platform_res_t request_device_size(platform_devctx_t const *devctx) {
   return PLATFORM_SUCCESS;
 }
 
-platform_res_t default_init(platform_devctx_t *devctx, size_t offboard_memory) {
+platform_res_t default_init(platform_devctx_t *devctx, platform_mem_addr_t offboard_memory) {
   default_platform_t *pp =
       (default_platform_t *)malloc(sizeof(default_platform_t));
   if (!pp)

--- a/runtime/platform/include/platform_device_operations.h
+++ b/runtime/platform/include/platform_device_operations.h
@@ -28,7 +28,7 @@ typedef struct platform_device_operations {
                               platform_ctl_addr_t const addr,
                               size_t const length, void const *data,
                               platform_ctl_flags_t const flags);
-  platform_res_t (*init)(platform_devctx_t *devctx, size_t offboard_memory);
+  platform_res_t (*init)(platform_devctx_t *devctx, platform_mem_addr_t offboard_memory);
   platform_res_t (*deinit)(platform_devctx_t const *devctx);
 } platform_device_operations_t;
 
@@ -76,7 +76,7 @@ platform_res_t default_write_ctl(platform_devctx_t const *devctx,
                                  size_t const length, void const *data,
                                  platform_ctl_flags_t const flags);
 
-platform_res_t default_init(platform_devctx_t *devctx, size_t offboard_memory);
+platform_res_t default_init(platform_devctx_t *devctx, platform_mem_addr_t offboard_memory);
 platform_res_t default_deinit(platform_devctx_t const *devctx);
 
 static inline void default_dops(platform_device_operations_t *dops) {

--- a/runtime/platform/include/platform_types.h
+++ b/runtime/platform/include/platform_types.h
@@ -58,7 +58,7 @@ typedef uint32_t platform_ctl_addr_t;
 #define PRIctl "%#08x"
 
 /** Device memory space address type (opaque). **/
-typedef uint32_t platform_mem_addr_t;
+typedef uint64_t platform_mem_addr_t;
 #define PRImem "%#08x"
 
 /** Identifies a slot in the design, i.e., a Function. **/


### PR DESCRIPTION
 - Fixes build errors introduced by the new status core
 - Fixes large transfer sizes not being displayed properly in tapasco-benchmark
 - Uses 64 bit memory addresses for all platforms