### PR TITLE
Don't preload arguments of previous job runs

### DIFF
--- a/runtime/arch/common/src/tapasco_jobs.c
+++ b/runtime/arch/common/src/tapasco_jobs.c
@@ -284,6 +284,8 @@ inline tapasco_job_id_t tapasco_jobs_acquire(tapasco_jobs_t *jobs) {
   if (j_id != INVALID_IDX) {
     jobs->q.elems[j_id].state = TAPASCO_JOB_STATE_REQUESTED;
     jobs->q.elems[j_id].args_len = 0;
+    for (size_t i = 0; i < TAPASCO_JOB_MAX_ARGS; i++)
+      jobs->q.elems[j_id].transfers[i].len = 0;
     j_id = jobs->q.elems[j_id].id;
     if (j_id > jobs->job_id_high_watermark) {
       jobs->job_id_high_watermark = j_id;


### PR DESCRIPTION
This fixes an issue when executing consecutive jobs:
1) A job with a pointer-argument (e.g. WrappedPointer) is started
2) The job is completed
3) A job with a normal argument is started
In this case the pointer from the first job is used as argument for the second job (instead of its intended argument)