### PR TITLE
Correctly signal Vivado errors

### DIFF
--- a/toolflow/scala/src/main/scala/tapasco/activity/composers/ComposerLog.scala
+++ b/toolflow/scala/src/main/scala/tapasco/activity/composers/ComposerLog.scala
@@ -44,7 +44,7 @@ class ComposerLog(val file: Path) {
     _ match { case (line, idx) => !RE_WARNING.findFirstIn(line).isEmpty }).toSeq
 
   /** Interprets the warnings and errors to generate a result value. */
-  def result: ComposeResult = if (errors.isEmpty) {
+  def result(failed : Boolean = false): ComposeResult = if (errors.isEmpty && !failed) {
     if ((warnings map (line => RE_TIMING.findFirstIn(line._1).isEmpty) fold true) (_ && _)) {
       Success
     } else {

--- a/toolflow/scala/src/main/scala/tapasco/activity/composers/VivadoComposer.scala
+++ b/toolflow/scala/src/main/scala/tapasco/activity/composers/VivadoComposer.scala
@@ -107,7 +107,7 @@ class VivadoComposer()(implicit cfg: Configuration) extends Composer {
       else{
         logger.error("Vivado finished with non-zero exit code: %d for %s in '%s'"
           .format(r, files.runName, files.outdir))
-        Composer.Result(files.log map (_.result) getOrElse OtherError, log = files.log,
+        Composer.Result(files.log map (_.result(true)) getOrElse OtherError, log = files.log,
           util = None, timing = None)
       }
     } else {

--- a/toolflow/scala/src/main/scala/tapasco/jobs/executors/HighLevelSynthesis.scala
+++ b/toolflow/scala/src/main/scala/tapasco/jobs/executors/HighLevelSynthesis.scala
@@ -89,6 +89,6 @@ protected object HighLevelSynthesis extends Executor[HighLevelSynthesisJob] {
     }
 
     // success, if all tasks were successful
-    ((tasks ++ importTasks) map (_.result) fold false) (_ || _)
+    ((tasks ++ importTasks) map (_.result) fold true) (_ && _)
   }
 }


### PR DESCRIPTION
This fixes #174 where TaPaSCo signals successful completion, even if Vivado returned an error.

For the first case, the evaluation after `hls` the problem was simply a bug in the folding of the results of the different subtasks.

For the second case, the failure in `compose` the problem was a little more involved: If Vivado returns a non-zero return code, TaPaSCo will try to detect the reason for the error by parsing the log file. But as a prompt exit, e.g. `exit 12`, does not leave any traces in the log, the log parser will not find any error messages and falsely signal success, which is propagated to the user.