### PR TITLE
Add load-bitstream to install

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -15,6 +15,10 @@ include(GNUInstallDirs)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D__MY_FILE__='\"$(subst ${CMAKE_SOURCE_DIR}/,,$(abspath $<))\"'")
 
+install(FILES platform/pcie/module/program_pcie.tcl DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/Tapasco/platform/pcie/module/)
+install(PROGRAMS platform/pcie/module/bit_reload.sh DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/Tapasco/platform/pcie/module/)
+install(PROGRAMS bin/tapasco-load-bitstream DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/Tapasco/bin)
+
 add_subdirectory(kernel)
 add_subdirectory(common)
 add_subdirectory(platform)

--- a/runtime/bin/tapasco-load-bitstream
+++ b/runtime/bin/tapasco-load-bitstream
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 import argparse
 import os
 import sys

--- a/runtime/bin/tapasco-load-bitstream
+++ b/runtime/bin/tapasco-load-bitstream
@@ -27,6 +27,9 @@ if args.verbose:
 	print('Reload Driver: {}'.format(str(args.reload_driver)))
 	print('Platform: {}'.format(os.environ['TAPASCO_PLATFORM']))
 
+if not 'TAPASCO_HOME_RUNTIME' in os.environ:
+    os.environ['TAPASCO_HOME_RUNTIME'] = "{}/../".format(os.getcwd())
+
 path = 'module/'
 reld = '-d' if args.reload_driver else ''
 verb = '-v' if args.verbose else ''


### PR DESCRIPTION
- Does so by copying the relevant files and intercepting a missing environment variable to determine if  the script is installed or not.
- Closes #185 