### PR TITLE
Properly catch HLS Crashes even if Return Code is 0

### DIFF
--- a/toolflow/scala/src/main/scala/tapasco/activity/hls/HighLevelSynthesizer.scala
+++ b/toolflow/scala/src/main/scala/tapasco/activity/hls/HighLevelSynthesizer.scala
@@ -126,5 +126,8 @@ object HighLevelSynthesizer {
   /** HLS run that failed due to another kind of error. */
   final case class OtherError(log: HighLevelSynthesizerLog, e: Exception) extends Result
 
+  /** HLS failed to produce a valid .zip-Archive as Result. */
+  final case class MissingZip(log: HighLevelSynthesizerLog) extends Result
+
 }
 

--- a/toolflow/scala/src/main/scala/tapasco/activity/hls/VivadoHighLevelSynthesis.scala
+++ b/toolflow/scala/src/main/scala/tapasco/activity/hls/VivadoHighLevelSynthesis.scala
@@ -77,11 +77,17 @@ private object VivadoHighLevelSynthesis extends HighLevelSynthesizer {
       logger.debug("Vivado HLS finished with exit code %d".format(vivadoRet))
       vivadoRet match {
         case 0 =>
-          logger.info("Vivado HLS finished successfully for {}", runName)
-          logger.trace("performing additional steps for {}", runName)
-          performAdditionalSteps(k, t)
-          logger.trace("additional steps for {} finished, copying zip", runName)
-          Success(HighLevelSynthesizerLog(logfile), copyZip(k, t).get)
+          val cp = copyZip(k, t)
+          if(cp.isEmpty) {
+            logger.info("Check Log-File for error: {}", logfile.toAbsolutePath.toString)
+            MissingZip(HighLevelSynthesizerLog(logfile))
+          } else {
+            logger.info("Vivado HLS finished successfully for {}", runName)
+            logger.trace("performing additional steps for {}", runName)
+            performAdditionalSteps(k, t)
+            logger.trace("additional steps for {} finished, copying zip", runName)
+            Success(HighLevelSynthesizerLog(logfile), copyZip(k, t).get)
+          }
         case InterruptibleProcess.TIMEOUT_RETCODE =>
           logger.error("Vivado HLS timeout for " + runName)
           Timeout(HighLevelSynthesizerLog(logfile))

--- a/toolflow/scala/src/main/scala/tapasco/activity/hls/VivadoHighLevelSynthesis.scala
+++ b/toolflow/scala/src/main/scala/tapasco/activity/hls/VivadoHighLevelSynthesis.scala
@@ -79,7 +79,7 @@ private object VivadoHighLevelSynthesis extends HighLevelSynthesizer {
         case 0 =>
           val cp = copyZip(k, t)
           if(cp.isEmpty) {
-            logger.error("Vivado HLS failed for {}", k.name)
+            logger.error("Vivado HLS failed for run: {}", runName)
             logger.info("Check Log-File for error: {}", logfile.toAbsolutePath.toString)
             MissingZip(HighLevelSynthesizerLog(logfile))
           } else {

--- a/toolflow/scala/src/main/scala/tapasco/activity/hls/VivadoHighLevelSynthesis.scala
+++ b/toolflow/scala/src/main/scala/tapasco/activity/hls/VivadoHighLevelSynthesis.scala
@@ -79,6 +79,7 @@ private object VivadoHighLevelSynthesis extends HighLevelSynthesizer {
         case 0 =>
           val cp = copyZip(k, t)
           if(cp.isEmpty) {
+            logger.error("Vivado HLS failed for {}", k.name)
             logger.info("Check Log-File for error: {}", logfile.toAbsolutePath.toString)
             MissingZip(HighLevelSynthesizerLog(logfile))
           } else {


### PR DESCRIPTION
This should fix #146.

CI: https://git.esa.informatik.tu-darmstadt.de/tapasco/tapasco/pipelines/1837