### PR TITLE
Clean up platform scripts (again)

### DIFF
--- a/toolflow/vivado/platform/aws/hooks/opt_design_pre.tcl
+++ b/toolflow/vivado/platform/aws/hooks/opt_design_pre.tcl
@@ -19,21 +19,26 @@
 
 puts "Running opt_design pre hook..."
 
+# Add design checkpoint of the F1 Shell with black-boxed custom logic (CL)
 add_files [file join $::env(HDK_SHELL_DIR) build checkpoints from_aws SH_CL_BB_routed.dcp]
 
-add_files [file join $::env(FAAS_CL_DIR) build checkpoints CL.post_synth.dcp]
-
-set_property SCOPED_TO_CELLS {WRAPPER_INST/CL} [get_files [file join $::env(FAAS_CL_DIR) build checkpoints CL.post_synth.dcp]]
+# Add design checkpoint of CL
+set post_synth_dcp [file join $::env(FAAS_CL_DIR) build checkpoints CL.post_synth.dcp]
+add_files $post_synth_dcp
+set_property SCOPED_TO_CELLS {WRAPPER_INST/CL} [get_files $post_synth_dcp]
 
 read_xdc [file join $::env(HDK_SHELL_DIR) build constraints cl_ddr.xdc]
 
 read_xdc $::env(PNR_USER)
-set_property PROCESSING_ORDER LATE [get_files $::env(PNR_USER)]
-set_property USED_IN {implementation} [get_files $::env(PNR_USER)]
+set_property -dict [list \
+  {PROCESSING_ORDER} {LATE} \
+  {USED_IN} {implementation} \
+] [get_files $::env(PNR_USER)]
 
 link_design -top top_sp -part [get_parts -of_objects [current_project]] \
   -reconfig_partitions {WRAPPER_INST/SH WRAPPER_INST/CL}
 
+# Allow MMCM-BUFGCE-MMCM cascade in different clock region columns
 set_property CLOCK_DEDICATED_ROUTE ANY_CMT_COLUMN [get_nets WRAPPER_INST/SH/kernel_clks_i/clkwiz_sys_clk/inst/CLK_CORE_DRP_I/clk_inst/clk_out2]
 set_property CLOCK_DEDICATED_ROUTE ANY_CMT_COLUMN [get_nets WRAPPER_INST/SH/kernel_clks_i/clkwiz_sys_clk/inst/CLK_CORE_DRP_I/clk_inst/clk_out3]
 


### PR DESCRIPTION
While looking through old todo lists, I found the first two points to be still open. Should be the last PR ;)

- `get_bd_pin` works, but the functions correct name is `get_bd_pins`
- Always use more explicit style `-of_objects .. -filter {NAME == ".."}` in `get_..` functions
- More consistent formatting
- Use string literals more often
- Again, some more comments