### PR TITLE
Add all platforms to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -371,6 +371,7 @@ tapasco_compose_ubuntu:
     XILINX_VIVADO: "/opt/cad/xilinx/vivado/Vivado/${VIVADO_VERSION}"
     XILINXD_LICENSE_FILE: "/opt/cad/keys/xilinx"
     PLATFORM: "pynq"
+    FLAGS: ""
   tags:
     - CAD
     - High
@@ -388,7 +389,7 @@ tapasco_compose_ubuntu:
     - /opt/tapasco/tapasco-init-toolflow.sh
     - source tapasco-setup-toolflow.sh
     - tapasco hls counter -p $PLATFORM --skipEvaluation
-    - tapasco -v --maxThreads 3 compose [counter x 3] @ 100 MHz -p $PLATFORM
+    - tapasco -v --maxThreads 3 compose [counter x 3] @ 100 MHz -p $PLATFORM $FLAGS
 
 tapasco_compose_17_4:
   variables:
@@ -425,3 +426,59 @@ tapasco_compose_pcie:
     VIVADO_VERSION: "2018.3"
     PLATFORM: "vc709"
   extends: .tapasco_compose
+
+# do runs without for synthesis for all other plattforms
+.tapasco_compose_no_synth:
+  variables:
+    FLAGS: "--skipSynthesis"
+  extends: .tapasco_compose
+
+tapasco_compose_AU250:
+  variables:
+    PLATFORM: "AU250"
+  extends: .tapasco_compose_no_synth
+
+tapasco_compose_netfpga_sume:
+  variables:
+    PLATFORM: "netfpga_sume"
+  extends: .tapasco_compose_no_synth
+
+tapasco_compose_ultra96v2:
+  variables:
+    PLATFORM: "ultra96v2"
+  extends: .tapasco_compose_no_synth
+
+tapasco_compose_vcu108:
+  variables:
+    PLATFORM: "vcu108"
+  extends: .tapasco_compose_no_synth
+
+tapasco_compose_vcu118:
+  variables:
+    PLATFORM: "vcu118"
+  extends: .tapasco_compose_no_synth
+
+tapasco_compose_vcu1525:
+  variables:
+    PLATFORM: "vcu1525"
+  extends: .tapasco_compose_no_synth
+
+tapasco_compose_xupvvh:
+  variables:
+    PLATFORM: "xupvvh"
+  extends: .tapasco_compose_no_synth
+
+tapasco_compose_zc706:
+  variables:
+    PLATFORM: "zc706"
+  extends: .tapasco_compose_no_synth
+
+tapasco_compose_zcu102:
+  variables:
+    PLATFORM: "zcu102"
+  extends: .tapasco_compose_no_synth
+
+tapasco_compose_zedboard:
+  variables:
+    PLATFORM: "zedboard"
+  extends: .tapasco_compose_no_synth

--- a/toolflow/vivado/platform/vcu1525/vcu1525.tcl
+++ b/toolflow/vivado/platform/vcu1525/vcu1525.tcl
@@ -32,11 +32,14 @@ namespace eval platform {
     apply_board_connection -board_interface "default_300mhz_clk0" -ip_intf "$name/C0_SYS_CLK" -diagram "system"
     apply_bd_automation -rule xilinx.com:bd_rule:board -config {Board_Interface "resetn ( FPGA Resetn ) " }  [get_bd_pins $name/sys_rst]
 
-    delete_bd_objs [get_bd_nets resetn_1]
-    set rst_inv [tapasco::ip::create_logic_vector "rst_inv_ddr_in"]
-    set_property -dict [list CONFIG.C_SIZE {1} CONFIG.C_OPERATION {not} CONFIG.LOGO_FILE {data/sym_notgate.png}] $rst_inv
-    connect_bd_net [get_bd_pins $rst_inv/Res] [get_bd_pins $name/sys_rst]
-    connect_bd_net [get_bd_pins resetn] [get_bd_pins $rst_inv/Op1]
+    if {[llength [get_bd_nets resetn_1]] > 0} {
+      puts "Applying workaround for Vivado automation bug ..."
+      delete_bd_objs [get_bd_nets resetn_1]
+      set rst_inv [tapasco::ip::create_logic_vector "rst_inv_ddr_in"]
+      set_property -dict [list CONFIG.C_SIZE {1} CONFIG.C_OPERATION {not} CONFIG.LOGO_FILE {data/sym_notgate.png}] $rst_inv
+      connect_bd_net [get_bd_pins $rst_inv/Res] [get_bd_pins $name/sys_rst]
+      connect_bd_net [get_bd_pins resetn] [get_bd_pins $rst_inv/Op1]
+    }
 
     connect_bd_intf_net [get_bd_intf_pins ${name}/C0_DDR4_S_AXI_CTRL] $s_axi_host
 


### PR DESCRIPTION
WIth this PR, we have a system composition of all supported TaPaSCo plattforms in the CI. In addition, the first detected error was fixed.