### PR TITLE
[WIP] Change the default permissions of the TLKM chardevs to 0666

### DIFF
--- a/runtime/kernel/device/tlkm_control.c
+++ b/runtime/kernel/device/tlkm_control.c
@@ -49,6 +49,7 @@ static int init_miscdev(struct tlkm_control *pctl)
 	pctl->miscdev.minor = MISC_DYNAMIC_MINOR;
 	pctl->miscdev.name = kstrdup(fn, GFP_KERNEL);
 	pctl->miscdev.fops = &_tlkm_control_fops;
+    pctl->miscdev.mode = S_IRUGO | S_IWUGO;
 	return misc_register(&pctl->miscdev);
 }
 

--- a/runtime/kernel/tlkm/tlkm.c
+++ b/runtime/kernel/tlkm/tlkm.c
@@ -53,6 +53,7 @@ int tlkm_init(void)
 	_tlkm.miscdev.name = TLKM_IOCTL_FN;
 	_tlkm.miscdev.fops = &_tlkm_fops;
 	_tlkm.is_setup = 1;
+    _tlkm.miscdev.mode = S_IRUGO | S_IWUGO;
 	return misc_register(&_tlkm.miscdev);
 }
 


### PR DESCRIPTION
This commit changes the default permissions of the TaPaSCo chardev to 0666, which means everyone can access it by default.

There are some pros and cons to this, which is why I marked this pull request as "Discussion".

For most users this should be more convenient, however, this is not really the Linux way to do things. In the Linux kernel there is the  saying: 'Policy belongs in user space, not in the kernel.'.

Accordingly, the proper way to do this is e.g. to use udev (and there should be a corresponding udev rule somewhere) which should be installed automatically in the release packages.

Hence, this is more a convenience feature for developers than anything else.

What do you think?