### PR TITLE
proper timeouted kill of vivado_hls subprocesses

### DIFF
--- a/toolflow/scala/src/main/scala/tapasco/activity/hls/VivadoHighLevelSynthesis.scala
+++ b/toolflow/scala/src/main/scala/tapasco/activity/hls/VivadoHighLevelSynthesis.scala
@@ -70,10 +70,12 @@ private object VivadoHighLevelSynthesis extends HighLevelSynthesizer {
       }
 
       // execute Vivado HLS (max. runtime: 1 day)
-      val vivadoRet = InterruptibleProcess(Process(Seq("vivado_hls",
+      val vivado_hls_cmd = Seq("timeout", (cfg.hlsTimeOut getOrElse (24 * 60 * 60)).toString, "vivado_hls",
         "-f", script.toString,
-        "-l", logfile.toString
-      ), script.getParent.toFile), waitMillis = Some(24 * 60 * 60 * 1000))
+        "-l", logfile.toString)
+      val process = Process(vivado_hls_cmd, script.getParent.toFile) 
+      val vivadoRet = InterruptibleProcess(process,
+         waitMillis = Some(24 * 60 * 60 * 1000))
         .!(ProcessLogger(line => logger.trace("Vivado HLS: {}", line),
           line => logger.trace("Vivado HLS ERR: {}", line)))
       lt.closeAll

--- a/toolflow/scala/src/main/scala/tapasco/activity/hls/VivadoHighLevelSynthesis.scala
+++ b/toolflow/scala/src/main/scala/tapasco/activity/hls/VivadoHighLevelSynthesis.scala
@@ -75,7 +75,7 @@ private object VivadoHighLevelSynthesis extends HighLevelSynthesizer {
         "-l", logfile.toString)
       val process = Process(vivado_hls_cmd, script.getParent.toFile) 
       val vivadoRet = InterruptibleProcess(process,
-         waitMillis = Some(24 * 60 * 60 * 1000))
+         waitMillis = Some(( cfg.hlsTimeOut getOrElse (24 * 60 * 60) ) * 1000 + 1000) )
         .!(ProcessLogger(line => logger.trace("Vivado HLS: {}", line),
           line => logger.trace("Vivado HLS ERR: {}", line)))
       lt.closeAll

--- a/toolflow/scala/src/main/scala/tapasco/base/Configuration.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/Configuration.scala
@@ -77,6 +77,10 @@ trait Configuration {
 
   def maxThreads(mt: Option[Int]): Configuration
 
+  def hlsTimeOut: Option[Int]
+
+  def hlsTimeOut(p: Option[Int]): Configuration
+
   def maxTasks: Option[Int]
 
   def maxTasks(mt: Option[Int]): Configuration

--- a/toolflow/scala/src/main/scala/tapasco/base/ConfigurationImpl.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/ConfigurationImpl.scala
@@ -50,6 +50,7 @@ private case class ConfigurationImpl(
                                       parallel: Boolean = false,
                                       maxThreads: Option[Int] = None,
                                       maxTasks: Option[Int] = None,
+                                      hlsTimeOut: Option[Int] = None,
                                       dryRun: Option[Path] = None,
                                       verbose: Option[String] = None,
                                       jobs: Seq[Job] = Seq()
@@ -85,6 +86,8 @@ private case class ConfigurationImpl(
   def parallel(enabled: Boolean): Configuration = this.copy(parallel = enabled)
 
   def maxThreads(mt: Option[Int]): Configuration = this.copy(maxThreads = mt)
+
+  def hlsTimeOut(timeout: Option[Int]): Configuration = this.copy(hlsTimeOut = timeout)
 
   def maxTasks(mt: Option[Int]): Configuration = this.copy(maxTasks = mt)
 

--- a/toolflow/scala/src/main/scala/tapasco/base/PrettyPrinter.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/PrettyPrinter.scala
@@ -88,6 +88,7 @@ private object PrettyPrinter {
     "Parallel = " + c.parallel,
     "MaxThreads = " + (c.maxThreads getOrElse "unlimited"),
     "MaxTasks = " + (c.maxTasks getOrElse "unlimited"),
+    "HlsTimeOut = " + (c.hlsTimeOut getOrElse "unlimited"),
     "Jobs = " + c.jobs
   ) mkString NL
 

--- a/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
@@ -406,6 +406,7 @@ package object json {
       (JsPath \ "Parallel").readNullable[Boolean].map(_ getOrElse false) ~
       (JsPath \ "MaxThreads").readNullable[Int] ~
       (JsPath \ "MaxTasks").readNullable[Int] ~
+      (JsPath \ "HlsTimeOut").readNullable[Int] ~
       (JsPath \ "DryRun").readNullable[Path] ~
       (JsPath \ "Verbose").readNullable[String] ~
       (JsPath \ "Jobs").read[Seq[Job]]
@@ -421,6 +422,7 @@ package object json {
       (JsPath \ "Slurm").write[Boolean] ~
       (JsPath \ "Parallel").write[Boolean] ~
       (JsPath \ "MaxThreads").writeNullable[Int] ~
+      (JsPath \ "HlsTimeOut").writeNullable[Int] ~
       (JsPath \ "MaxTasks").writeNullable[Int] ~
       (JsPath \ "DryRun").writeNullable[Path].transform((js: JsObject) => js - "DryRun") ~
       (JsPath \ "Verbose").writeNullable[String] ~

--- a/toolflow/scala/src/main/scala/tapasco/parser/GlobalOptions.scala
+++ b/toolflow/scala/src/main/scala/tapasco/parser/GlobalOptions.scala
@@ -51,7 +51,8 @@ private object GlobalOptions {
       longOption("parallel") |
       longOption("slurm") |
       longOption("maxThreads") |
-      longOption("maxTasks")
+      longOption("maxTasks") |
+      longOption("hlsTimeOut")
     ).opaque("a global option")
 
   def help: Parser[(String, String)] =
@@ -112,8 +113,11 @@ private object GlobalOptions {
   def maxTasks: Parser[(String, Int)] =
     longOption("maxTasks", "MaxTasks") ~/ ws ~ posint ~ ws
 
+  def hlsTimeOut: Parser[(String, Int)] =
+    longOption("hlsTimeOut", "HlsTimeOut") ~/ ws ~ posint ~ ws
+
   def globalOptionsSeq: Parser[Seq[(String, _)]] =
-    ws ~ (help | verbose | dirs | inputFiles | slurm | parallel | dryRun | maxThreads | maxTasks).rep
+    ws ~ (help | verbose | dirs | inputFiles | slurm | parallel | dryRun | maxThreads | maxTasks | hlsTimeOut).rep
 
   def globalOptions: Parser[Configuration] =
     globalOptionsSeq map (as => mkConfig(as))
@@ -135,6 +139,7 @@ private object GlobalOptions {
         case ("DryRun", p: Path) => mkConfig(as, Some(c getOrElse Configuration() dryRun Some(p)))
         case ("MaxThreads", i: Int) => mkConfig(as, Some(c getOrElse Configuration() maxThreads Some(i)))
         case ("MaxTasks", i: Int) => mkConfig(as, Some(c getOrElse Configuration() maxTasks Some(i)))
+        case ("HlsTimeOut", i: Int) => mkConfig(as, Some(c getOrElse Configuration() hlsTimeOut Some(i)))
         case ("Verbose", m: String) => mkConfig(as, Some(c getOrElse Configuration() verbose Some(m)))
         case _ => c getOrElse Configuration()
       }

--- a/toolflow/scala/src/main/scala/tapasco/parser/Usage.scala
+++ b/toolflow/scala/src/main/scala/tapasco/parser/Usage.scala
@@ -92,6 +92,8 @@ configuration via `tapasco -n config.json`.
       Arg("--parallel", "Execute all jobs in parallel (careful!)") &
       Arg("--maxThreads NUM", "Limit internal parallelism of tasks (e.g., Vivado)" ~
         "to the given number of threads.") &
+      Arg("--hlsTimeOut NUM", "Limit runtime of Vivado HLS to" ~
+        "the given number of seconds.") &
       Arg("--maxTasks NUM", "Limit the parallelism of TaPaSCo to the given number." ~
         "This includes the main thread, so at most NUM-1 tasks are started in addition to the main thread."))
 


### PR DESCRIPTION
Hi everyone,

with this PR TaPaSCo accepts the additional command line flag `--hlsTimeOut <int>`. It enables the configuration of the previously hard-coded timeout given to the ctor of `interruptibleProcess`.

Previously the command

`$ /usr/Xilinx/Vivado/2018.2/bin/vivado_hls -f <script.tcl> -l <logfile.log>`

was executed. Unfortunately, a `InterruptibleProcess`-Object seems to only send `SIGTERM` to the process that it spawned. 

`/usr/Xilinx/Vivado/2018.2/bin/vivado_hls` is a script that calls `/usr/Xilinx/Vivado/2018.2/bin/loader` which calls  `/usr/Xilinx/Vivado/2018.2/bin/unwrapped/lnx64.o/vivado_hls` (the actual HSL process). However, InterruptibleProcess only sends the signal to the PID of the three processes after the timeout and thus only ever terminates the top-level bash script leaving the HLS process running in the background.

This might be a problem in the timeout for calls to `vivado`.

Best regards
Florian