### PR TITLE
Add support for Alveo U280

### DIFF
--- a/runtime/platform/pcie/module/program_pcie.tcl
+++ b/runtime/platform/pcie/module/program_pcie.tcl
@@ -21,7 +21,7 @@
 
 #set default values
 set wait 1000
-set dev {xc7vx690t_0|xcvu9p_0|xcvu095_0|xcu250_0|xcvu37p_0}
+set dev {xc7vx690t_0|xcvu9p_0|xcvu095_0|xcu250_0|xcvu37p_0|xcu280_0}
 set probes_file {}
 set program_file {}
 set devid -1

--- a/toolflow/vivado/platform/AU280/AU280.tcl
+++ b/toolflow/vivado/platform/AU280/AU280.tcl
@@ -51,7 +51,7 @@ namespace eval platform {
 
     set mig [tapasco::ip::create_us_ddr ${name}]
     apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {ddr4_sdram_c1 ( DDR4 SDRAM C1 ) } Manual_Source {Auto}}  [get_bd_intf_pins $mig/C0_DDR4]
-    apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {sysclk1 ( 100 MHz System differential clock0 ) } Manual_Source {Auto}}  [get_bd_intf_pins $mig/C0_SYS_CLK]
+    apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {sysclk1 ( 100 MHz System differential clock1 ) } Manual_Source {Auto}}  [get_bd_intf_pins $mig/C0_SYS_CLK]
     apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {resetn ( FPGA Resetn ) } Manual_Source {New External Port (ACTIVE_HIGH)}}  [get_bd_pins $mig/sys_rst]
 
 

--- a/toolflow/vivado/platform/AU280/AU280.tcl
+++ b/toolflow/vivado/platform/AU280/AU280.tcl
@@ -1,0 +1,200 @@
+# Copyright (c) 2014-2020 Embedded Systems and Applications, TU Darmstadt.
+#
+# This file is part of TaPaSCo
+# (see https://github.com/esa-tu-darmstadt/tapasco).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+namespace eval platform {
+  set platform_dirname "AU280"
+  set pcie_width "x16"
+
+  source $::env(TAPASCO_HOME_TCL)/platform/pcie/pcie_base.tcl
+
+  if {[tapasco::is_feature_enabled "HBM"]} {
+
+    proc get_ignored_segments { } {
+      set hbmInterfaces [hbm::get_hbm_interfaces]
+      set ignored [list]
+      for {set i 0} {$i < [llength $hbmInterfaces]} {incr i} {
+        for {set j 0} {$j < [llength $hbmInterfaces]} {incr j} {
+          set axi_index [format %02s $i]
+          set mem_index [format %02s $j]
+          lappend ignored "/hbm/hbm_0/SAXI_${axi_index}/HBM_MEM${mem_index}"
+        }
+      }
+      return $ignored
+    }
+
+  }
+
+  proc create_mig_core {name} {
+    puts "Creating MIG core for DDR ..."
+    set s_axi_host [create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 "S_MEM_CTRL"]
+
+    set mig [tapasco::ip::create_us_ddr ${name}]
+    apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {ddr4_sdram_c0 ( DDR4 SDRAM C0 ) } Manual_Source {Auto}}  [get_bd_intf_pins $mig/C0_DDR4]
+    apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {sysclk0 ( 100 MHz System differential clock0 ) } Manual_Source {Auto}}  [get_bd_intf_pins $mig/C0_SYS_CLK]
+    apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {resetn ( FPGA Resetn ) } Manual_Source {New External Port (ACTIVE_HIGH)}}  [get_bd_pins $mig/sys_rst]
+
+
+    connect_bd_intf_net [get_bd_intf_pins $mig/C0_DDR4_S_AXI_CTRL] $s_axi_host
+
+    set const [tapasco::ip::create_constant constz 1 0]
+    make_bd_pins_external $const
+
+    set constraints_fn "$::env(TAPASCO_HOME_TCL)/platform/AU280/board.xdc"
+    read_xdc $constraints_fn
+    set_property PROCESSING_ORDER EARLY [get_files $constraints_fn]
+
+    set inst [current_bd_instance -quiet .]
+    current_bd_instance -quiet
+
+    set m_si [create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:aximm_rtl:1.0 host/M_MEM_CTRL]
+
+    set num_mi_old [get_property CONFIG.NUM_MI [get_bd_cells host/out_ic]]
+    set num_mi [expr "$num_mi_old + 1"]
+    set_property -dict [list CONFIG.NUM_MI $num_mi] [get_bd_cells host/out_ic]
+    connect_bd_intf_net $m_si [get_bd_intf_pins host/out_ic/[format "M%02d_AXI" $num_mi_old]]
+
+    current_bd_instance -quiet $inst
+
+    return $mig
+  }
+  
+
+  proc create_pcie_core {} {
+    puts "Creating AXI PCIe Gen3 bridge ..."
+
+    set pcie_core [tapasco::ip::create_axi_pcie3_0_usp axi_pcie3_0]
+
+    apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {pci_express_x16 ( PCI Express ) } Manual_Source {Auto}}  [get_bd_intf_pins $pcie_core/pcie_mgt]
+    apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {pcie_perstn ( PCI Express ) } Manual_Source {New External Port (ACTIVE_LOW)}}  [get_bd_pins $pcie_core/sys_rst_n]
+
+    apply_bd_automation -rule xilinx.com:bd_rule:xdma -config { accel {1} auto_level {IP Level} axi_clk {Maximum Data Width} axi_intf {AXI Memory Mapped} bar_size {Disable} bypass_size {Disable} c2h {4} cache_size {32k} h2c {4} lane_width {X16} link_speed {8.0 GT/s (PCIe Gen 3)}}  [get_bd_cells $pcie_core]
+
+    set pcie_properties [list \
+      CONFIG.functional_mode {AXI_Bridge} \
+      CONFIG.mode_selection {Advanced} \
+      CONFIG.pcie_blk_locn {PCIE4C_X1Y0} \
+      CONFIG.pl_link_cap_max_link_width {X16} \
+      CONFIG.pl_link_cap_max_link_speed {8.0_GT/s} \
+      CONFIG.axi_addr_width {64} \
+      CONFIG.pipe_sim {true} \
+      CONFIG.pf0_revision_id {01} \
+      CONFIG.pf0_base_class_menu {Memory_controller} \
+      CONFIG.pf0_sub_class_interface_menu {Other_memory_controller} \
+      CONFIG.pf0_interrupt_pin {NONE} \
+      CONFIG.pf0_msi_enabled {false} \
+      CONFIG.SYS_RST_N_BOARD_INTERFACE {pcie_perstn} \
+      CONFIG.PCIE_BOARD_INTERFACE {pci_express_x16} \
+      CONFIG.pf0_msix_enabled {true} \
+      CONFIG.c_m_axi_num_write {32} \
+      CONFIG.pf0_msix_impl_locn {External} \
+      CONFIG.pf0_bar0_size {64} \
+      CONFIG.pf0_bar0_scale {Megabytes} \
+      CONFIG.pf0_bar0_64bit {true} \
+      CONFIG.axi_data_width {512_bit} \
+      CONFIG.pf0_device_id {7038} \
+      CONFIG.pf0_class_code_base {05} \
+      CONFIG.pf0_class_code_sub {80} \
+      CONFIG.pf0_class_code_interface {00} \
+      CONFIG.xdma_axilite_slave {true} \
+      CONFIG.coreclk_freq {500} \
+      CONFIG.plltype {QPLL1} \
+      CONFIG.pf0_msix_cap_table_size {83} \
+      CONFIG.pf0_msix_cap_table_offset {20000} \
+      CONFIG.pf0_msix_cap_table_bir {BAR_1:0} \
+      CONFIG.pf0_msix_cap_pba_offset {28000} \
+      CONFIG.pf0_msix_cap_pba_bir {BAR_1:0} \
+      CONFIG.bar_indicator {BAR_1:0} \
+      CONFIG.bar0_indicator {0}
+      ]
+
+    if {[catch {set_property -dict $pcie_properties $pcie_core}]} {
+      error "ERROR: Failed to configure PCIe bridge. This may be related to the format settings of your OS for numbers. Please check that it is set to 'United States' (see AR# 51331)"
+    }
+    set_property -dict $pcie_properties $pcie_core
+
+
+    tapasco::ip::create_msixusptrans "MSIxTranslator" $pcie_core
+
+    return $pcie_core
+  }
+
+  # Checks if the optional register slice given by the name is enabled (based on regslice feature and default value)
+  proc is_regslice_enabled {name default} {
+    if {[tapasco::is_feature_enabled "Regslice"]} {
+      set regslices [tapasco::get_feature "Regslice"]
+      if  {[dict exists $regslices $name]} {
+          return [dict get $regslices $name]
+        } else {
+          return $default
+        }
+    } else {
+      return $default
+    }
+  }
+
+  # Inserts a new register slice between given master and slave (for SLR crossing)
+  proc insert_regslice {name default master slave clock reset subsystem} {
+    if {[is_regslice_enabled $name $default]} {
+      set regslice [create_bd_cell -type ip -vlnv xilinx.com:ip:axi_register_slice:2.1 $subsystem/regslice_${name}]
+      set_property -dict [list CONFIG.REG_AW {15} CONFIG.REG_AR {15} CONFIG.REG_W {15} CONFIG.REG_R {15} CONFIG.REG_B {15} CONFIG.USE_AUTOPIPELINING {1}] $regslice
+      delete_bd_objs [get_bd_intf_nets -of_objects [get_bd_intf_pins $master]]
+      connect_bd_intf_net [get_bd_intf_pins $master] [get_bd_intf_pins $regslice/S_AXI]
+      connect_bd_intf_net [get_bd_intf_pins $regslice/M_AXI] [get_bd_intf_pins $slave]
+      connect_bd_net [get_bd_pins $clock] [get_bd_pins $regslice/aclk]
+      connect_bd_net [get_bd_pins $reset] [get_bd_pins $regslice/aresetn]
+    }
+  }
+
+  # Insert optional register slices
+  proc insert_regslices {} {
+    insert_regslice "dma_migic" false "/memory/dma/m32_axi" "/memory/mig_ic/S00_AXI" "/memory/mem_clk" "/memory/mem_peripheral_aresetn" "/memory"
+    insert_regslice "host_memctrl" true "/host/M_MEM_CTRL" "/memory/S_MEM_CTRL" "/clocks_and_resets/mem_clk" "/clocks_and_resets/mem_interconnect_aresetn" ""
+    insert_regslice "arch_mem" false "/arch/M_MEM_0" "/memory/S_MEM_0" "/clocks_and_resets/design_clk" "/clocks_and_resets/design_interconnect_aresetn" ""
+    insert_regslice "host_dma" true "/host/M_DMA" "/memory/S_DMA" "/clocks_and_resets/host_clk" "/clocks_and_resets/host_interconnect_aresetn" ""
+    insert_regslice "dma_host" true "/memory/M_HOST" "/host/S_HOST" "/clocks_and_resets/host_clk" "/clocks_and_resets/host_interconnect_aresetn" ""
+    insert_regslice "host_arch" true "/host/M_ARCH" "/arch/S_ARCH" "/clocks_and_resets/design_clk" "/clocks_and_resets/design_interconnect_aresetn" ""
+
+    if {[is_regslice_enabled "pe" false]} {
+      set ips [get_bd_cells /arch/target_ip_*]
+      foreach ip $ips {
+        set masters [tapasco::get_aximm_interfaces $ip]
+        foreach master $masters {
+          set slave [get_bd_intf_pins -filter {MODE == Slave} -of_objects [get_bd_intf_nets -of_objects $master]]
+          insert_regslice [get_property NAME $ip] true $master $slave "/arch/design_clk" "/arch/design_interconnect_aresetn" "/arch"
+        }
+      }
+    }
+  }
+
+  namespace eval AU280 {
+        namespace export addressmap
+
+        proc addressmap {args} {
+            # add ECC config to platform address map
+            set args [lappend args "M_MEM_CTRL" [list 0x40000 0x10000 0 "PLATFORM_COMPONENT_ECC"]]
+            return $args
+        }
+    }
+
+
+  tapasco::register_plugin "platform::AU280::addressmap" "post-address-map"
+
+  tapasco::register_plugin "platform::insert_regslices" "post-platform"
+
+}

--- a/toolflow/vivado/platform/AU280/AU280.tcl
+++ b/toolflow/vivado/platform/AU280/AU280.tcl
@@ -50,8 +50,8 @@ namespace eval platform {
     set s_axi_host [create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 "S_MEM_CTRL"]
 
     set mig [tapasco::ip::create_us_ddr ${name}]
-    apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {ddr4_sdram_c0 ( DDR4 SDRAM C0 ) } Manual_Source {Auto}}  [get_bd_intf_pins $mig/C0_DDR4]
-    apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {sysclk0 ( 100 MHz System differential clock0 ) } Manual_Source {Auto}}  [get_bd_intf_pins $mig/C0_SYS_CLK]
+    apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {ddr4_sdram_c1 ( DDR4 SDRAM C1 ) } Manual_Source {Auto}}  [get_bd_intf_pins $mig/C0_DDR4]
+    apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {sysclk1 ( 100 MHz System differential clock0 ) } Manual_Source {Auto}}  [get_bd_intf_pins $mig/C0_SYS_CLK]
     apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {resetn ( FPGA Resetn ) } Manual_Source {New External Port (ACTIVE_HIGH)}}  [get_bd_pins $mig/sys_rst]
 
 

--- a/toolflow/vivado/platform/AU280/AU280.tcl
+++ b/toolflow/vivado/platform/AU280/AU280.tcl
@@ -21,6 +21,11 @@ namespace eval platform {
   set platform_dirname "AU280"
   set pcie_width "x16"
 
+  if { [::tapasco::vivado_is_newer "2020.1"] == 0 } {
+    puts "Vivado [version -short] is too old to support AU280."
+    exit 1
+  }
+
   source $::env(TAPASCO_HOME_TCL)/platform/pcie/pcie_base.tcl
 
   if {[tapasco::is_feature_enabled "HBM"]} {

--- a/toolflow/vivado/platform/AU280/board.xdc
+++ b/toolflow/vivado/platform/AU280/board.xdc
@@ -1,0 +1,37 @@
+# Copyright (c) 2014-2020 Embedded Systems and Applications, TU Darmstadt.
+#
+# This file is part of TaPaSCo
+# (see https://github.com/esa-tu-darmstadt/tapasco).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+
+# ------------------------------------------------------------------------
+set_property CONFIG_VOLTAGE 1.8 [current_design]
+set_property BITSTREAM.CONFIG.CONFIGFALLBACK Enable [current_design]
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
+set_property CONFIG_MODE SPIx4 [current_design]
+set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]
+set_property BITSTREAM.CONFIG.CONFIGRATE 85.0 [current_design]
+set_property BITSTREAM.CONFIG.EXTMASTERCCLK_EN disable [current_design]
+set_property BITSTREAM.CONFIG.SPI_FALL_EDGE YES [current_design]
+set_property BITSTREAM.CONFIG.UNUSEDPIN Pullup [current_design]
+set_property BITSTREAM.CONFIG.SPI_32BIT_ADDR Yes [current_design]
+# ------------------------------------------------------------------------
+
+set_property PACKAGE_PIN D32 [get_ports {dout_0[0]}]
+
+set_property IOSTANDARD LVCMOS18 [get_ports {dout_0[0]}]

--- a/toolflow/vivado/platform/AU280/platform.json
+++ b/toolflow/vivado/platform/AU280/platform.json
@@ -1,0 +1,12 @@
+{
+	"Name" : "AU280",
+	"Description" : "Alveo U280 Data Center Accelerator Card",
+	"TclLibrary" : "AU280.tcl",
+	"Part" : "xcu280-fsvh2892-2L-e",
+	"BoardPart" : "xilinx.com:au280:part0:1.1",
+	"BoardPreset" : "AU280",
+	"TargetUtilization" : 90,
+	"Benchmark" : "AU280.benchmark",
+	"HostFrequency": 250.0,
+	"MemFrequency": 300.0
+}

--- a/toolflow/vivado/platform/AU280/plugins/hbm.tcl
+++ b/toolflow/vivado/platform/AU280/plugins/hbm.tcl
@@ -294,12 +294,12 @@ namespace eval hbm {
 
       # apply constraints for one or both stacks
       current_bd_instance /hbm
-      set constraints_l "$::env(TAPASCO_HOME_TCL)/platform/xupvvh/plugins/hbm_l.xdc"
+      set constraints_l "$::env(TAPASCO_HOME_TCL)/platform/AU280/plugins/hbm_l.xdc"
       read_xdc $constraints_l
       set_property PROCESSING_ORDER EARLY [get_files $constraints_l]
 
       if {$bothStacks} {
-        set constraints_r "$::env(TAPASCO_HOME_TCL)/platform/xupvvh/plugins/hbm_r.xdc"
+        set constraints_r "$::env(TAPASCO_HOME_TCL)/platform/AU280/plugins/hbm_r.xdc"
         read_xdc $constraints_r
         set_property PROCESSING_ORDER EARLY [get_files $constraints_r]
       }

--- a/toolflow/vivado/platform/AU280/plugins/hbm.tcl
+++ b/toolflow/vivado/platform/AU280/plugins/hbm.tcl
@@ -1,0 +1,352 @@
+# Copyright (c) 2014-2020 Embedded Systems and Applications, TU Darmstadt.
+#
+# This file is part of TaPaSCo
+# (see https://github.com/esa-tu-darmstadt/tapasco).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+if {[tapasco::is_feature_enabled "HBM"]} {
+  proc create_custom_subsystem_hbm {{args {}}} {
+
+    set hbmInterfaces [hbm::get_hbm_interfaces]
+
+    hbm::validate_pe_configuration $hbmInterfaces
+
+    set numInterfaces [llength $hbmInterfaces]
+    set bothStacks [expr ($numInterfaces > 16)]
+
+    hbm::create_refclk_ports $bothStacks
+
+    hbm::generate_hbm_core $hbmInterfaces
+    
+  }
+}
+
+namespace eval hbm {
+
+  # Extracts AXI-MM masters with HBM access from feature configuration
+  proc get_hbm_interfaces {} {
+    set hbmInterfaces [list]
+
+    set hbm [tapasco::get_feature "HBM"]
+
+    set value [dict values [dict remove $hbm enabled]]
+
+    foreach kernel $value {
+      dict with kernel {
+        set core [find_ID $ID]
+        # select required number PEs of given type
+        set end [expr ($Count - 1)]
+        set PEs [lrange [get_bd_cells /arch/target_ip_[format %02d $core]_*] 0 $end]
+        foreach PE $PEs {
+          foreach interface $Interfaces {
+            # select all given interfaces of the given PEs
+            set hbmInterfaces [lappend hbmInterfaces [format "%s/%s" $PE $interface]]
+          }
+        }
+      }
+    }
+    return $hbmInterfaces
+  }
+
+  proc validate_pe_configuration {hbmInterfaces} {
+    set numInterfaces [llength $hbmInterfaces]
+
+    if { $numInterfaces > 32 } {
+      puts "Currently only 32 Master interfaces with HBM connection supported."
+      puts "Got $hbmInterfaces"
+      exit
+    }
+
+    if { $numInterfaces == 0 } {
+      puts "No IP with HBM connections found."
+      puts "Disable Feature HBM if not used."
+      exit
+    }
+  }
+
+  # Creates input ports for reference clock(s)
+  proc create_refclk_ports {bothStacks} {
+      set hbm_ref_clk_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 hbm_ref_clk_0 ]
+      set_property CONFIG.FREQ_HZ 100000000 $hbm_ref_clk_0
+  }
+
+  # Creates HBM configuration for given number of active HBM ports
+  proc create_hbm_properties {numInterfaces} {
+    # disable APB debug port
+    # disable AXI crossbar (global addressing)
+    # configure AXI clock freq
+    set hbm_properties [list \
+      CONFIG.USER_APB_EN {false} \
+      CONFIG.USER_SWITCH_ENABLE_00 {false} \
+      CONFIG.USER_SWITCH_ENABLE_01 {false} \
+      CONFIG.USER_AXI_INPUT_CLK_FREQ {450} \
+      CONFIG.USER_AXI_INPUT_CLK_NS {2.222} \
+      CONFIG.USER_AXI_INPUT_CLK_PS {2222} \
+      CONFIG.USER_AXI_INPUT_CLK_XDC {2.222} \
+      CONFIG.HBM_MMCM_FBOUT_MULT0 {51} \
+      CONFIG.USER_XSDB_INTF_EN {FALSE}
+    ]
+
+    # configure stacks used
+    if {$numInterfaces <= 16} {
+      set maxSlaves 16
+      lappend hbm_properties \
+        CONFIG.USER_HBM_DENSITY {4GB} \
+        CONFIG.USER_HBM_STACK {1} \
+    } else {
+      set maxSlaves 32
+      lappend hbm_properties \
+        CONFIG.USER_HBM_DENSITY {8GB} \
+    }
+
+
+    # enable HBM ports and memory controllers as required (two ports per mc)
+    for {set i $numInterfaces} {$i < $maxSlaves} {incr i} {
+      set saxi [format %02s $i]
+      lappend hbm_properties CONFIG.USER_SAXI_${saxi} {false}
+      if ([even $i]) {
+        set mc [format %02s [expr {$i / 2}]]
+        lappend hbm_properties CONFIG.USER_MC_ENABLE_${mc} {false}
+      }
+    }
+
+
+    # configure memory controllers
+    for {set i 0} {$i < $maxSlaves} {incr i} {
+      if ([even $i]) {
+        set mc [format %s [expr {$i / 2}]]
+        lappend hbm_properties CONFIG.USER_MC${mc}_ECC_BYPASS false
+        lappend hbm_properties CONFIG.USER_MC${mc}_ECC_CORRECTION false
+        lappend hbm_properties CONFIG.USER_MC${mc}_EN_DATA_MASK true
+        lappend hbm_properties CONFIG.USER_MC${mc}_TRAFFIC_OPTION {Linear}
+        lappend hbm_properties CONFIG.USER_MC${mc}_BG_INTERLEAVE_EN true
+      }
+    }
+
+    return $hbm_properties
+  }
+
+  # Creates HBM clocking infrastructure for a single stack
+  proc create_clocking {name port} {
+    set group [create_bd_cell -type hier $name]
+    set instance [current_bd_instance .]
+    current_bd_instance $group
+
+    set hbm_ref_clk [create_bd_pin -type "clk" -dir "O" "hbm_ref_clk"]
+    set axi_clk_0 [create_bd_pin -type "clk" -dir "O" "axi_clk_0"]
+    set axi_clk_1 [create_bd_pin -type "clk" -dir "O" "axi_clk_1"]
+    set axi_clk_2 [create_bd_pin -type "clk" -dir "O" "axi_clk_2"]
+    set axi_clk_3 [create_bd_pin -type "clk" -dir "O" "axi_clk_3"]
+    set axi_clk_4 [create_bd_pin -type "clk" -dir "O" "axi_clk_4"]
+    set axi_clk_5 [create_bd_pin -type "clk" -dir "O" "axi_clk_5"]
+    set axi_clk_6 [create_bd_pin -type "clk" -dir "O" "axi_clk_6"]
+    set axi_reset [create_bd_pin -type "rst" -dir "O" "axi_reset"]
+    set mem_peripheral_aresetn [create_bd_pin -type "rst" -dir "I" "mem_peripheral_aresetn"]
+
+    set ibuf [tapasco::ip::create_util_buf ibuf]
+    set_property -dict [ list CONFIG.C_BUF_TYPE {IBUFDS}  ] $ibuf
+
+    connect_bd_intf_net $port [get_bd_intf_pins $ibuf/CLK_IN_D]
+
+    set clk_wiz [tapasco::ip::create_clk_wiz clk_wiz]
+    set_property -dict [list CONFIG.PRIM_SOURCE {No_buffer} CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {450} CONFIG.CLKOUT2_REQUESTED_OUT_FREQ {450} CONFIG.CLKOUT3_REQUESTED_OUT_FREQ {450} CONFIG.CLKOUT4_REQUESTED_OUT_FREQ {450} CONFIG.CLKOUT5_REQUESTED_OUT_FREQ {450} CONFIG.CLKOUT6_REQUESTED_OUT_FREQ {450} CONFIG.CLKOUT7_REQUESTED_OUT_FREQ {450} CONFIG.CLKOUT2_USED {true} CONFIG.CLKOUT3_USED {true} CONFIG.CLKOUT4_USED {true} CONFIG.CLKOUT5_USED {true} CONFIG.CLKOUT6_USED {true} CONFIG.CLKOUT7_USED {true} CONFIG.RESET_TYPE {ACTIVE_LOW} CONFIG.NUM_OUT_CLKS {7} CONFIG.RESET_PORT {resetn}] $clk_wiz
+
+    connect_bd_net [get_bd_pins $ibuf/IBUF_OUT] $hbm_ref_clk
+    connect_bd_net [get_bd_pins $ibuf/IBUF_OUT] [get_bd_pins $clk_wiz/clk_in1]
+
+    connect_bd_net $mem_peripheral_aresetn [get_bd_pins $clk_wiz/resetn]
+
+    set reset_generator [tapasco::ip::create_logic_vector reset_generator]
+    set_property -dict [list CONFIG.C_SIZE {1} CONFIG.C_OPERATION {and} CONFIG.LOGO_FILE {data/sym_andgate.png}] $reset_generator
+
+    connect_bd_net $mem_peripheral_aresetn [get_bd_pins $reset_generator/Op1]
+    connect_bd_net [get_bd_pins $clk_wiz/locked] [get_bd_pins $reset_generator/Op2]
+
+    for {set i 0} {$i < 7} {incr i} {
+      set incr [expr $i + 1]
+      connect_bd_net [get_bd_pins axi_clk_${i}] [get_bd_pins $clk_wiz/clk_out${incr}]
+    }
+
+    connect_bd_net $axi_reset [get_bd_pins $reset_generator/Res]
+
+    current_bd_instance $instance
+    connect_bd_net [get_bd_pins mem_peripheral_aresetn] $mem_peripheral_aresetn
+    return $group
+  }
+
+  # Connects a range of HBM AXI clocks with the outputs of a clocking infrastructure
+  proc connect_clocking {clocking hbm startInterface numInterfaces} {
+    for {set i 0} {$i < $numInterfaces} {incr i} {
+        set hbm_index [format %02s [expr $i + $startInterface]]
+        set block_index [expr $i < 16 ? 0 : 1]
+        set clk_index [expr ($i % 16) / 2]
+        set clk_index [expr $clk_index < 7 ? $clk_index : 6]
+        connect_bd_net [get_bd_pins $clocking/axi_reset] [get_bd_pins $hbm/AXI_${hbm_index}_ARESET_N]
+        connect_bd_net [get_bd_pins $clocking/axi_clk_${clk_index}] [get_bd_pins $hbm/AXI_${hbm_index}_ACLK]
+      }
+  }
+
+  # Ṕrovides HBM access for the given AXI-MM masters
+  proc generate_hbm_core {hbmInterfaces} {
+    if {[tapasco::is_feature_enabled "HBM"]} {
+      puts "Generating HBM Core"
+      set numInterfaces [llength $hbmInterfaces]
+      set bothStacks [expr ($numInterfaces > 16)]
+
+      set hbm_properties [create_hbm_properties $numInterfaces]
+
+      # create and configure HBM IP
+      set hbm [ create_bd_cell -type ip -vlnv xilinx.com:ip:hbm:1.0 "hbm_0" ]
+      set_property -dict $hbm_properties $hbm
+
+      # create and connect clocking infrastructure for left stack
+      set clocking_0 [create_clocking "clocking_0" [get_bd_intf_ports /hbm_ref_clk_0]]
+      connect_clocking $clocking_0 $hbm 0 [expr min($numInterfaces,16)]
+      connect_bd_net [get_bd_pins $clocking_0/hbm_ref_clk] [get_bd_pins $hbm/HBM_REF_CLK_0]
+
+      connect_bd_net [get_bd_pins $clocking_0/hbm_ref_clk] [get_bd_pins $hbm/APB_0_PCLK]
+      connect_bd_net [get_bd_pins /host/axi_pcie3_0/user_lnk_up] [get_bd_pins $hbm/APB_0_PRESET_N]
+
+      if {$bothStacks} {
+        # create and connect clocking infrastructure for right stack
+        set clocking_1 [create_clocking "clocking_1" [get_bd_intf_ports /hbm_ref_clk_0]]
+        connect_clocking $clocking_1 $hbm 16 [expr $numInterfaces - 16]
+        connect_bd_net [get_bd_pins $clocking_1/hbm_ref_clk] [get_bd_pins $hbm/HBM_REF_CLK_1]
+
+        connect_bd_net [get_bd_pins $clocking_1/hbm_ref_clk] [get_bd_pins $hbm/APB_1_PCLK]
+        connect_bd_net [get_bd_pins /host/axi_pcie3_0/user_lnk_up] [get_bd_pins $hbm/APB_1_PRESET_N]
+      }
+
+      # remove standard memory interconnect network
+      delete_bd_objs [get_bd_cells /arch/out_*]
+      delete_bd_objs [get_bd_intf_pins /arch/M_MEM_*]
+
+      for {set i 0} {$i < $numInterfaces} {incr i} {
+        variable master [lindex $hbmInterfaces $i]
+
+        set pin [create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:aximm_rtl:1.0 /arch/M_AXI_HBM_${i}]
+        connect_bd_intf_net $pin $master
+
+        set hbm_index [format %02s $i]
+
+        # create smartconnect for clock domain conversion, protocol conversion (AXI4->AXI3) and data width conversion
+        set converter [create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 smartconnect_${i}]
+        set_property -dict [list CONFIG.NUM_SI {1} CONFIG.NUM_CLKS {2} CONFIG.HAS_ARESETN {0}] $converter
+        
+        # create connections between PE and smartconnect, and smartconnect and HBM
+
+        connect_bd_net [get_bd_pins design_clk] [get_bd_pins $converter/aclk]
+        connect_bd_net [get_bd_pins $hbm/AXI_${hbm_index}_ACLK] [get_bd_pins $converter/aclk1]
+
+        if {[platform::is_regslice_enabled "hbm_pe" false] || [platform::is_regslice_enabled [format "hbm_pe%s" $hbm_index] false]} {
+          # insert register slice between PE and smartconnect
+          set regslice_pre [create_bd_cell -type ip -vlnv xilinx.com:ip:axi_register_slice:2.1 regslice_pre_${i}]
+          set_property -dict [list CONFIG.REG_AW {15} CONFIG.REG_AR {15} CONFIG.REG_W {15} CONFIG.REG_R {15} CONFIG.REG_B {15} CONFIG.USE_AUTOPIPELINING {1}] $regslice_pre
+
+          connect_bd_intf_net $pin [get_bd_intf_pins $regslice_pre/S_AXI]
+          connect_bd_intf_net [get_bd_intf_pins $regslice_pre/M_AXI] [get_bd_intf_pins $converter/S00_AXI]
+
+          connect_bd_net [get_bd_pins design_clk] [get_bd_pins $regslice_pre/aclk]
+          connect_bd_net [get_bd_pins design_interconnect_aresetn] [get_bd_pins $regslice_pre/aresetn]
+        } else {
+          connect_bd_intf_net $pin [get_bd_intf_pins $converter/S00_AXI]
+        }
+
+        if {[platform::is_regslice_enabled "hbm_hbm" false] || [platform::is_regslice_enabled [format "hbm_hbm%s" $hbm_index] false]} {
+          # insert register slice between smartconnect and HBM
+          set regslice_post [create_bd_cell -type ip -vlnv xilinx.com:ip:axi_register_slice:2.1 regslice_post_${i}]
+          set_property -dict [list CONFIG.REG_AW {15} CONFIG.REG_AR {15} CONFIG.REG_W {15} CONFIG.REG_R {15} CONFIG.REG_B {15} CONFIG.USE_AUTOPIPELINING {1}] $regslice_post
+
+          connect_bd_intf_net [get_bd_intf_pins $converter/M00_AXI] [get_bd_intf_pins $regslice_post/S_AXI]
+          connect_bd_intf_net [get_bd_intf_pins $regslice_post/M_AXI] [get_bd_intf_pins $hbm/SAXI_${hbm_index}]
+          connect_bd_net [get_bd_pins $hbm/AXI_${hbm_index}_ACLK] [get_bd_pins $regslice_post/aclk]
+          connect_bd_net [get_bd_pins $hbm/AXI_${hbm_index}_ARESET_N] [get_bd_pins $regslice_post/aresetn]
+        } else {
+          connect_bd_intf_net [get_bd_intf_pins $converter/M00_AXI] [get_bd_intf_pins $hbm/SAXI_${hbm_index}]
+        }
+
+      }
+
+      # recreate memory interconnect network for AXI-MM masters not connected to HBM
+      current_bd_instance /arch
+      set mgroups [platform::max_masters]
+      set masters [ldiff [lsort -dictionary [tapasco::get_aximm_interfaces [get_bd_cells /arch/target_ip_*]]] $hbmInterfaces]
+      set arch_mem_ics [arch::arch_create_mem_interconnects $mgroups [llength $masters]]
+      arch::arch_connect_mem $arch_mem_ics $masters
+      catch {arch::arch_connect_clocks} issue
+      catch {arch::arch_connect_resets} issue
+
+      # apply constraints for one or both stacks
+      current_bd_instance /hbm
+      set constraints_l "$::env(TAPASCO_HOME_TCL)/platform/xupvvh/plugins/hbm_l.xdc"
+      read_xdc $constraints_l
+      set_property PROCESSING_ORDER EARLY [get_files $constraints_l]
+
+      if {$bothStacks} {
+        set constraints_r "$::env(TAPASCO_HOME_TCL)/platform/xupvvh/plugins/hbm_r.xdc"
+        read_xdc $constraints_r
+        set_property PROCESSING_ORDER EARLY [get_files $constraints_r]
+      }
+
+
+    }
+  }
+
+  proc addressmap {{args {}}} {
+    if {[tapasco::is_feature_enabled "HBM"]} {
+      set hbmInterfaces [get_hbm_interfaces]
+      for {set i 0} {$i < [llength $hbmInterfaces]} {incr i} {
+        set base [expr {0x10000000 * $i}]
+        set args [lappend args M_AXI_HBM_${i} [list $base 0 -1 ""]]
+      }
+      
+    }
+    return $args
+  }
+
+  proc ldiff {a b} {
+    lmap elem $a {
+        expr {[lsearch -exact $b $elem] > -1 ? [continue] : $elem}
+    }
+  }
+
+  proc lmap {varname listval body} {
+    upvar 1 $varname var
+    set temp [list]
+    foreach var $listval {
+        lappend temp [uplevel 1 $body]
+    }
+    set temp
+  }
+
+  proc even x {expr {($x % 2) == 0}}
+
+  proc find_ID {input} {
+    set composition [tapasco::get_composition]
+    for {set o 0} {$o < [llength $composition] -1} {incr o} {
+      if {[regexp ".*:$input:.*" [dict get $composition $o vlnv]]} {
+        return $o
+      }
+    }
+    return -1
+  }
+
+
+}
+
+
+tapasco::register_plugin "platform::hbm::addressmap" "post-address-map"

--- a/toolflow/vivado/platform/AU280/plugins/hbm.tcl
+++ b/toolflow/vivado/platform/AU280/plugins/hbm.tcl
@@ -80,7 +80,7 @@ namespace eval hbm {
 
   # Creates input ports for reference clock(s)
   proc create_refclk_ports {bothStacks} {
-      set hbm_ref_clk_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 hbm_ref_clk_0 ]
+      set hbm_ref_clk_0 [ create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 hbm_ref_clk ]
       set_property CONFIG.FREQ_HZ 100000000 $hbm_ref_clk_0
   }
 
@@ -213,7 +213,7 @@ namespace eval hbm {
       set ibuf [tapasco::ip::create_util_buf ibuf]
       set_property -dict [ list CONFIG.C_BUF_TYPE {IBUFDS}  ] $ibuf
 
-      connect_bd_intf_net [get_bd_intf_ports /hbm_ref_clk_0] [get_bd_intf_pins $ibuf/CLK_IN_D]
+      connect_bd_intf_net [get_bd_intf_ports /hbm_ref_clk] [get_bd_intf_pins $ibuf/CLK_IN_D]
 
       # create and connect clocking infrastructure for left stack
       set clocking_0 [create_clocking "clocking_0" [get_bd_pins $ibuf/IBUF_OUT]]

--- a/toolflow/vivado/platform/AU280/plugins/hbm_l.xdc
+++ b/toolflow/vivado/platform/AU280/plugins/hbm_l.xdc
@@ -19,15 +19,15 @@
 
 # Constraints for left HBM stack
 
-set_property PACKAGE_PIN BJ43 [get_ports hbm_ref_clk_0_clk_p]
-set_property PACKAGE_PIN BJ44 [get_ports hbm_ref_clk_0_clk_n]
-set_property IOSTANDARD LVDS [get_ports hbm_ref_clk_0_clk_p]
-set_property IOSTANDARD LVDS [get_ports hbm_ref_clk_0_clk_n]
-set_property DQS_BIAS TRUE [get_ports hbm_ref_clk_0_clk_p]
+set_property PACKAGE_PIN BJ43 [get_ports hbm_ref_clk_clk_p]
+set_property PACKAGE_PIN BJ44 [get_ports hbm_ref_clk_clk_n]
+set_property IOSTANDARD LVDS [get_ports hbm_ref_clk_clk_p]
+set_property IOSTANDARD LVDS [get_ports hbm_ref_clk_clk_n]
+set_property DQS_BIAS TRUE [get_ports hbm_ref_clk_clk_p]
 
-create_clock -period 10 -name sysclk0 [get_ports hbm_ref_clk_0_clk_p]
+create_clock -period 10 -name sysclk0 [get_ports hbm_ref_clk_clk_p]
 
-set_clock_groups -asynchronous -group [get_clocks hbm_ref_clk_0_clk_p -include_generated_clocks]
+set_clock_groups -asynchronous -group [get_clocks hbm_ref_clk_clk_p -include_generated_clocks]
 set_clock_groups -asynchronous -group [get_clocks clk_out1_system_clk_wiz_0 -include_generated_clocks]
 set_clock_groups -asynchronous -group [get_clocks clk_out2_system_clk_wiz_0 -include_generated_clocks]
 set_clock_groups -asynchronous -group [get_clocks clk_out3_system_clk_wiz_0 -include_generated_clocks]

--- a/toolflow/vivado/platform/AU280/plugins/hbm_l.xdc
+++ b/toolflow/vivado/platform/AU280/plugins/hbm_l.xdc
@@ -1,0 +1,40 @@
+# Copyright (c) 2014-2020 Embedded Systems and Applications, TU Darmstadt.
+#
+# This file is part of TaPaSCo
+# (see https://github.com/esa-tu-darmstadt/tapasco).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Constraints for left HBM stack
+
+set_property PACKAGE_PIN BJ43 [get_ports hbm_ref_clk_0_clk_p]
+set_property PACKAGE_PIN BJ44 [get_ports hbm_ref_clk_0_clk_n]
+set_property IOSTANDARD LVDS [get_ports hbm_ref_clk_0_clk_p]
+set_property IOSTANDARD LVDS [get_ports hbm_ref_clk_0_clk_n]
+set_property DQS_BIAS TRUE [get_ports hbm_ref_clk_0_clk_p]
+
+create_clock -period 10 -name sysclk0 [get_ports hbm_ref_clk_0_clk_p]
+
+set_clock_groups -asynchronous -group [get_clocks hbm_ref_clk_0_clk_p -include_generated_clocks]
+set_clock_groups -asynchronous -group [get_clocks clk_out1_system_clk_wiz_0 -include_generated_clocks]
+set_clock_groups -asynchronous -group [get_clocks clk_out2_system_clk_wiz_0 -include_generated_clocks]
+set_clock_groups -asynchronous -group [get_clocks clk_out3_system_clk_wiz_0 -include_generated_clocks]
+set_clock_groups -asynchronous -group [get_clocks clk_out4_system_clk_wiz_0 -include_generated_clocks]
+set_clock_groups -asynchronous -group [get_clocks clk_out5_system_clk_wiz_0 -include_generated_clocks]
+set_clock_groups -asynchronous -group [get_clocks clk_out6_system_clk_wiz_0 -include_generated_clocks]
+set_clock_groups -asynchronous -group [get_clocks clk_out7_system_clk_wiz_0 -include_generated_clocks]
+
+
+set_property CLOCK_DEDICATED_ROUTE BACKBONE [get_nets system_i/hbm/clocking_0/ibuf/U0/IBUF_OUT[0]]

--- a/toolflow/vivado/platform/AU280/plugins/hbm_r.xdc
+++ b/toolflow/vivado/platform/AU280/plugins/hbm_r.xdc
@@ -1,0 +1,29 @@
+# Copyright (c) 2014-2020 Embedded Systems and Applications, TU Darmstadt.
+#
+# This file is part of TaPaSCo
+# (see https://github.com/esa-tu-darmstadt/tapasco).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Constraints for right HBM stack
+
+
+set_clock_groups -asynchronous -group [get_clocks clk_out1_system_clk_wiz_1 -include_generated_clocks]
+set_clock_groups -asynchronous -group [get_clocks clk_out2_system_clk_wiz_1 -include_generated_clocks]
+set_clock_groups -asynchronous -group [get_clocks clk_out3_system_clk_wiz_1 -include_generated_clocks]
+set_clock_groups -asynchronous -group [get_clocks clk_out4_system_clk_wiz_1 -include_generated_clocks]
+set_clock_groups -asynchronous -group [get_clocks clk_out5_system_clk_wiz_1 -include_generated_clocks]
+set_clock_groups -asynchronous -group [get_clocks clk_out6_system_clk_wiz_1 -include_generated_clocks]
+set_clock_groups -asynchronous -group [get_clocks clk_out7_system_clk_wiz_1 -include_generated_clocks]


### PR DESCRIPTION
Adds support for the U280 including

-  PCIe connection to host
-  DDR4 MIG for memory access (currently only one DIMM is used)
-  HBM support as alternative memory (via feature parser)
-  Optional Register slices for timing closure (configurable via feature parser)
-  Requires Vivado 2020.1
