### PR TITLE
Fix a false positive when parsing Vivado logfile during Composition

### DIFF
--- a/toolflow/scala/src/main/scala/tapasco/activity/composers/ComposerLog.scala
+++ b/toolflow/scala/src/main/scala/tapasco/activity/composers/ComposerLog.scala
@@ -75,7 +75,7 @@ object ComposerLog {
       logger.warn("could not read logfile " + file + ": " + e); None
   }
 
-  private val RE_ERROR = """(?i)(^[^_]*error)|(\(file .*tcl\" line)""".r
+  private val RE_ERROR = """(?i)(^[^_]*(?<! 0 )error)|(\(file .*tcl\" line)""".r
   private val RE_WARNING = """(?i)warn""".r
   private val RE_PLACER = """(?i)(Placer could not place all instances)|(ERROR:\s*\[Place)""".r
   private val RE_TIMING = """Timing 38-282""".r


### PR DESCRIPTION
Since the string `0 Infos, 0 Warnings, 0 Critical Warnings and 0 Errors encountered.` contains the the substring `error` it was treated as error message. Adapt regex such that ` 0 error` is not matched anymore.