### PR TITLE
Officially support CentOS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -214,6 +214,16 @@ build_kernel_arm64v8_debug:
     paths:
       - runtime/kernel/tlkm.ko
 
+build_kernel_centos_8:
+  image: centos:8
+  extends: .build_kernel_fedora
+
+build_kernel_centos_8_debug:
+  image: centos:8
+  variables:
+    MODE: "all"
+  extends: .build_kernel_fedora
+
 build_kernel_fedora_30:
   image: fedora:30
   extends: .build_kernel_fedora
@@ -260,6 +270,16 @@ build_kernel_fedora_31_debug:
     paths:
       - build/tapasco-*-Linux.rpm
   extends: .build_tapasco
+
+build_tapasco_centos_8:
+  image: centos:8
+  extends: .build_tapasco_fedora
+
+build_tapasco_centos_8_debug:
+  variables:
+    MODE: "debug"
+  image: centos:8
+  extends: .build_tapasco_fedora
 
 build_tapasco_fedora_30:
   image: fedora:30

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ TaPaSCo is known to work in this environment:
 
 *   Intel x86_64 arch
 *   Linux kernel 4.4+
-*   Fedora 30+, Ubuntu 16.04+
+*   CentOS 8, Fedora 30+, Ubuntu 16.04+
 *   Fedora 24/25 does not support debug mode due to GCC bug
 *   Bash Shell 4.2.x+
 


### PR DESCRIPTION
As Vivado 2020.1 finally added support for CentOS 8 and CentOS 8 is the first CentOS release with quite modern GCC 8.3 and Linux kernel 4.18, we can finally add official support for CentOS to TaPaSCo.