### PR TITLE
Feature/slurm remote support

### DIFF
--- a/toolflow/scala/src/main/scala/tapasco/Tapasco.scala
+++ b/toolflow/scala/src/main/scala/tapasco/Tapasco.scala
@@ -87,7 +87,12 @@ object Tapasco {
       logger.trace("configuring FileAssetManager...")
       FileAssetManager(cfg)
       logger.trace("SLURM: {}", cfg.slurm)
-      if (cfg.slurm) Slurm.enabled = cfg.slurm
+      if (cfg.slurm.isDefined) {
+        Slurm.set_cfg(cfg.slurm.get match {
+          case "local" => Slurm.EnabledLocal()
+          case t       => Slurm.EnabledRemote(t)
+        })
+      }
       FileAssetManager.start()
       logger.trace("parallel: {}", cfg.parallel)
       cfg.logFile map { logfile: Path => setupLogFileAppender(logfile.toString) }

--- a/toolflow/scala/src/main/scala/tapasco/base/Configuration.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/Configuration.scala
@@ -65,9 +65,9 @@ trait Configuration {
 
   def logFile(p: Option[Path]): Configuration
 
-  def slurm: Boolean
+  def slurm: Option[String]
 
-  def slurm(enabled: Boolean): Configuration
+  def slurm(template: Option[String]): Configuration
 
   def parallel: Boolean
 

--- a/toolflow/scala/src/main/scala/tapasco/base/ConfigurationImpl.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/ConfigurationImpl.scala
@@ -46,7 +46,7 @@ private case class ConfigurationImpl(
                                       private val _coreDir: Path = BasePathManager.DEFAULT_DIR_CORES,
                                       private val _compositionDir: Path = BasePathManager.DEFAULT_DIR_COMPOSITIONS,
                                       private val _logFile: Option[Path] = None,
-                                      slurm: Boolean = false,
+                                      slurm: Option[String] = None,
                                       parallel: Boolean = false,
                                       maxThreads: Option[Int] = None,
                                       maxTasks: Option[Int] = None,
@@ -81,7 +81,7 @@ private case class ConfigurationImpl(
 
   def logFile(op: Option[Path]): Configuration = this.copy(_logFile = op)
 
-  def slurm(enabled: Boolean): Configuration = this.copy(slurm = enabled)
+  def slurm(template: Option[String]): Configuration = this.copy(slurm = template)
 
   def parallel(enabled: Boolean): Configuration = this.copy(parallel = enabled)
 
@@ -97,8 +97,10 @@ private case class ConfigurationImpl(
 
   def jobs(js: Seq[Job]): Configuration = this.copy(jobs = js)
 
-  // these directories must exist
-  for ((d, n) <- Seq((archDir, "architectures"),
-    (platformDir, "platforms")))
-    require(mustExist(d), "%s directory %s does not exist".format(n, d.toString))
+  // these directories must exist, unless we execute on remote SLURM node
+  if (this.slurm.getOrElse(true).equals("local")) {
+    for ((d, n) <- Seq((archDir, "architectures"),
+      (platformDir, "platforms")))
+      require(mustExist(d), "%s directory %s does not exist".format(n, d.toString))
+  }
 }

--- a/toolflow/scala/src/main/scala/tapasco/base/SlurmRemoteConfig.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/SlurmRemoteConfig.scala
@@ -37,7 +37,9 @@ case class SlurmRemoteConfig(
                               workdir: Path,
                               installdir: Path,
                               jobFile: String,
-                              SbatchOptions: String
+                              SbatchOptions: String,
+                              PreambleScript: Option[String],
+                              PostambleScript: Option[String]
                             )
 
 object SlurmRemoteConfig extends Builds[SlurmRemoteConfig]

--- a/toolflow/scala/src/main/scala/tapasco/base/SlurmRemoteConfig.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/SlurmRemoteConfig.scala
@@ -36,7 +36,8 @@ case class SlurmRemoteConfig(
                               workstation: String,
                               workdir: Path,
                               installdir: Path,
-                              jobFile: String
+                              jobFile: String,
+                              SbatchOptions: String
                             )
 
 object SlurmRemoteConfig extends Builds[SlurmRemoteConfig]

--- a/toolflow/scala/src/main/scala/tapasco/base/SlurmRemoteConfig.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/SlurmRemoteConfig.scala
@@ -1,0 +1,42 @@
+/*
+ *
+ * Copyright (c) 2014-2020 Embedded Systems and Applications, TU Darmstadt.
+ *
+ * This file is part of TaPaSCo
+ * (see https://github.com/esa-tu-darmstadt/tapasco).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+/**
+  * @file SlurmRemoteConfig.scala
+  * @brief Model: TPC remote Slurm Configuration.
+  * @authors M. Hartmann, TU Darmstadt
+  **/
+
+package tapasco.base
+
+import java.nio.file.Path
+import tapasco.base.builder.Builds
+
+case class SlurmRemoteConfig(
+                              name: String,
+                              host: String,
+                              workstation: String,
+                              workdir: Path,
+                              installdir: Path,
+                              jobFile: String
+                            )
+
+object SlurmRemoteConfig extends Builds[SlurmRemoteConfig]

--- a/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
@@ -445,7 +445,8 @@ package object json {
       (JsPath \ "WorkstationHost").read[String](minimumLength(length = 1)) ~
       (JsPath \ "Workdir").read[Path] ~
       (JsPath \ "TapascoInstallDir").read[Path] ~
-      (JsPath \ "JobFile").read[String](minimumLength(length = 1))
+      (JsPath \ "JobFile").read[String](minimumLength(length = 1)) ~
+      (JsPath \ "SbatchOptions").readNullable[String].map(_.getOrElse(""))
     ) (SlurmRemoteConfig.apply _)
   /* SlurmRemoteConfig @} */
 

--- a/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
@@ -437,6 +437,18 @@ package object json {
   }
 
   /* Configuration @} */
+
+  /* @{ SlurmRemoteConfig */
+  implicit val slurmRemoteConfigReads: Reads[SlurmRemoteConfig] = (
+      (JsPath \ "Name").read[String](minimumLength(length = 1)) ~
+      (JsPath \ "SlurmHost").read[String](minimumLength(length = 1)) ~
+      (JsPath \ "WorkstationHost").read[String](minimumLength(length = 1)) ~
+      (JsPath \ "Workdir").read[Path] ~
+      (JsPath \ "TapascoInstallDir").read[Path] ~
+      (JsPath \ "JobFile").read[String](minimumLength(length = 1))
+    ) (SlurmRemoteConfig.apply _)
+  /* SlurmRemoteConfig @} */
+
 }
 
 // vim: foldmarker=@{,@} foldmethod=marker foldlevel=0

--- a/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
@@ -402,7 +402,7 @@ package object json {
       (JsPath \ "CoreDir").readNullable[Path].map(_ getOrElse BasePathManager.DEFAULT_DIR_CORES) ~
       (JsPath \ "CompositionDir").readNullable[Path].map(_ getOrElse BasePathManager.DEFAULT_DIR_COMPOSITIONS) ~
       (JsPath \ "LogFile").readNullable[Path] ~
-      (JsPath \ "Slurm").readNullable[Boolean].map(_ getOrElse false) ~
+      (JsPath \ "Slurm").readNullable[String] ~
       (JsPath \ "Parallel").readNullable[Boolean].map(_ getOrElse false) ~
       (JsPath \ "MaxThreads").readNullable[Int] ~
       (JsPath \ "MaxTasks").readNullable[Int] ~
@@ -419,7 +419,7 @@ package object json {
       (JsPath \ "CoreDir").write[Path] ~
       (JsPath \ "CompositionDir").write[Path] ~
       (JsPath \ "LogFile").writeNullable[Path] ~
-      (JsPath \ "Slurm").write[Boolean] ~
+      (JsPath \ "Slurm").writeNullable[String] ~
       (JsPath \ "Parallel").write[Boolean] ~
       (JsPath \ "MaxThreads").writeNullable[Int] ~
       (JsPath \ "HlsTimeOut").writeNullable[Int] ~

--- a/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
@@ -446,7 +446,9 @@ package object json {
       (JsPath \ "Workdir").read[Path] ~
       (JsPath \ "TapascoInstallDir").read[Path] ~
       (JsPath \ "JobFile").read[String](minimumLength(length = 1)) ~
-      (JsPath \ "SbatchOptions").readNullable[String].map(_.getOrElse(""))
+      (JsPath \ "SbatchOptions").readNullable[String].map(_.getOrElse("")) ~
+      (JsPath \ "PreambleScript").readNullable[String] ~
+      (JsPath \ "PostambleScript").readNullable[String]
     ) (SlurmRemoteConfig.apply _)
   /* SlurmRemoteConfig @} */
 

--- a/toolflow/scala/src/main/scala/tapasco/parser/GlobalOptions.scala
+++ b/toolflow/scala/src/main/scala/tapasco/parser/GlobalOptions.scala
@@ -96,8 +96,8 @@ private object GlobalOptions {
   def inputFiles: Parser[(String, Path)] =
     jobsFile | configFile | logFile
 
-  def slurm: Parser[(String, Boolean)] =
-    longOption("slurm", "Slurm").map((_, true)) ~ ws
+  def slurm: Parser[(String, String)] =
+    longOption("slurm", "Slurm") ~ ws ~/ string.opaque("slurm template name") ~ ws
 
   def parallel: Parser[(String, Boolean)] =
     longOption("parallel", "Parallel").map((_, true)) ~ ws
@@ -131,7 +131,7 @@ private object GlobalOptions {
         case ("Core", p: Path) => mkConfig(as, Some(c getOrElse Configuration() coreDir p))
         case ("Kernel", p: Path) => mkConfig(as, Some(c getOrElse Configuration() kernelDir p))
         case ("Platform", p: Path) => mkConfig(as, Some(c getOrElse Configuration() platformDir p))
-        case ("Slurm", e: Boolean) => mkConfig(as, Some(c getOrElse Configuration() slurm e))
+        case ("Slurm", t: String) => mkConfig(as, Some(c getOrElse Configuration() slurm Some(t)))
         case ("Parallel", e: Boolean) => mkConfig(as, Some(c getOrElse Configuration() parallel e))
         case ("JobsFile", p: Path) => mkConfig(as, Some(c getOrElse Configuration() jobs readJobsFile(p)))
         case ("LogFile", p: Path) => mkConfig(as, Some(c getOrElse Configuration() logFile Some(p)))

--- a/toolflow/scala/src/main/scala/tapasco/parser/Usage.scala
+++ b/toolflow/scala/src/main/scala/tapasco/parser/Usage.scala
@@ -88,7 +88,8 @@ configuration via `tapasco -n config.json`.
       Arg("--logFile FILE", "Path to output log file") &
       Arg("--configFile FILE", "Path to Json file with Configuration") &
       Arg("--jobsFile FILE", "Path to Json file with Jobs array") &
-      Arg("--slurm", "Activate SLURM cluster execution (requires sbatch)") &
+      Arg("--slurm TEMPLATE", "Activate SLURM cluster execution." ~
+        "TEMPLATE describes a remote SLURM node, use 'local' for local execution (requires sbatch).") &
       Arg("--parallel", "Execute all jobs in parallel (careful!)") &
       Arg("--maxThreads NUM", "Limit internal parallelism of tasks (e.g., Vivado)" ~
         "to the given number of threads.") &

--- a/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
+++ b/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
@@ -207,9 +207,12 @@ final object Slurm extends Publisher {
       }
       case _ => files
     }
-
     val remote_files = local_files map update_paths
     file_transfer(local_files.zip(remote_files).toMap, tx = true)
+
+    // run preamble script, if specified
+    if (slurm_remote_cfg.get.PreambleScript.isDefined)
+      "sh %s".format(slurm_remote_cfg.get.PreambleScript.get).!
   }
 
   /**
@@ -234,9 +237,12 @@ final object Slurm extends Publisher {
       }
       case _ => files
     }
-
     val remote_files = loc_files map update_paths
     file_transfer(remote_files.zip(loc_files).toMap, tx=false)
+
+    // run postamble script, if specified
+    if (slurm_remote_cfg.get.PostambleScript.isDefined)
+      "sh %s".format(slurm_remote_cfg.get.PostambleScript.get).!
   }
 
   /**

--- a/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
+++ b/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
@@ -397,19 +397,19 @@ final object Slurm extends Publisher {
       val cmd = "scancel %s" format (ids mkString " ")
       logger.info("canceling SLURM jobs: {}", ids mkString ", ")
       logger.debug("command: '{}'", cmd)
-      exec_cmd(cmd, get_ret_code = true).toInt
+      exec_cmd(cmd)
     }
   }
 
   /** Execute a SLURM command, either locally or on a remote host */
-  def exec_cmd(c: String, get_ret_code: Boolean = false, hostname: Option[String] = None): String = {
+  def exec_cmd(c: String, hostname: Option[String] = None): String = {
     val cmd = if (slurm_remote_cfg.isEmpty) c else {
       val host = hostname.getOrElse(slurm_remote_cfg.get.host)
       "ssh %s %s".format(host, c)
     }
 
     logger.info("Executing command: %s".format(cmd))
-    if (get_ret_code) cmd.!.toString else cmd.!!
+    cmd.!!
   }
 
   /** Use SLURM? */

--- a/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
+++ b/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
@@ -277,8 +277,12 @@ final object Slurm extends Publisher {
         new_pre.resolve(postfix)
       }
     }
-    val wd_to_rmt   = if (slurm_remote_cfg.isDefined) prefix_subst(cfg.kernelDir.getParent, slurm_remote_cfg.get.workdir) else (x: Path) => x
-    val tpsc_to_rmt = if (slurm_remote_cfg.isDefined) prefix_subst(cfg.platformDir.getParent.getParent.getParent, slurm_remote_cfg.get.installdir) else (x: Path) => x
+    val wd_to_rmt   = if (slurm_remote_cfg.isDefined)
+      prefix_subst(cfg.kernelDir.getParent, slurm_remote_cfg.get.workdir)
+    else identity[Path] _
+    val tpsc_to_rmt = if (slurm_remote_cfg.isDefined)
+      prefix_subst(cfg.platformDir.getParent.getParent.getParent, slurm_remote_cfg.get.installdir)
+    else identity[Path] _
 
     /** Create non-slurm cfg, with updated paths such that they match the folder structure on SLURM node */
     val newCfg = cfg

--- a/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
+++ b/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
@@ -218,12 +218,10 @@ final object Slurm extends Publisher {
   def slurm_postamble(slurm_job: Job, files: Seq[Path], update_paths: Path => Path): Unit = {
     val loc_files = slurm_job.job match {
       case ComposeJob(c, f, _, a, p, _, _, _, _, _) => {
-        val tgt = Target.fromString(a.get.head, p.get.head).get
-        val bit = slurm_job.log.resolveSibling( Composer.mkProjectName(c, tgt, f) + ".bit" )
-        val bin = slurm_job.log.resolveSibling( Composer.mkProjectName(c, tgt, f) + ".bit.bin" )
+        val bit_name = Composer.mkProjectName(c, Target.fromString(a.get.head, p.get.head).get, f)
+        val fnames = Seq(bit_name + ".bit", bit_name + ".bit.bin", "timing.txt", "utilization.txt")
 
-        // TODO: Is this sufficient, or do we also need the timing/utilization report (or simply pull whole composition folder) ?
-        files ++ Seq(bit, bin)
+        files ++ fnames.map(f => slurm_job.log.resolveSibling(f))
       }
       case HighLevelSynthesisJob(_, a,p, kernels, _) => {
         val tgt = Target.fromString(a.get.head, p.get.head).get

--- a/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
+++ b/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
@@ -310,7 +310,13 @@ final object Slurm extends Publisher {
         slurm_preamble(slurm_job, files_to_copy, wd_to_rmt)
       }
 
-      val cmd = "sbatch %s".format(wd_to_rmt(jobFile.toAbsolutePath()).normalize().toString)
+      val cmd = "sbatch %s %s".format(
+        slurm_remote_cfg match {
+          case Some(c) => c.SbatchOptions
+          case None => ""
+        },
+        wd_to_rmt(jobFile.toAbsolutePath()).normalize().toString
+      )
       logger.debug("running slurm batch job: '%s'".format(cmd))
 
       var id: Option[Int] = None

--- a/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
+++ b/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
@@ -173,7 +173,11 @@ final object Slurm extends Publisher {
     Files.createDirectories(file.getParent())
     // write file
     val fw = new java.io.FileWriter(file.toString)
-    fw.append(jobScript.interpolateFile(SLURM_TEMPLATE_DIR.resolve(slurm_remote_cfg.get.jobFile).toString))
+    val template_name = slurm_remote_cfg match {
+      case Some(c) => c.jobFile
+      case None => "default.job.template"
+    }
+    fw.append(jobScript.interpolateFile(SLURM_TEMPLATE_DIR.resolve(template_name).toString))
     fw.flush()
     fw.close()
     // set executable permissions
@@ -352,7 +356,8 @@ final object Slurm extends Publisher {
     }
 
     // callback that pulls generated files from remote node
-    postambles(id)(id)
+    if (slurm_remote_cfg.isDefined)
+      postambles(id)(id)
   }
 
   /** Returns a list of all SLURM job ids which are registered under the

--- a/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
+++ b/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
@@ -174,6 +174,85 @@ final object Slurm extends Publisher {
   }
 
   /**
+    * Preamble is run before the SLURM job is started.
+    * Copy required files from host to SLURM workstation.
+    * @param slurm_job  Job to execute.
+    * @param files List of files that need to be copied to SLURM node
+    * @param update_paths Function that converts local workdir file paths to valid paths on a remote SLURM node.
+    **/
+  def slurm_preamble(slurm_job: Job, files: Seq[Path], update_paths: Path => Path)(implicit cfg: Configuration): Unit = {
+    val local_files: Seq[Path] = slurm_job.job match {
+      case ComposeJob(c, _, _, a, p, _, _, _, _, _) => {
+        val tgt = Target.fromString(a.get.head, p.get.head).get
+        val cores = c.composition.map(ce => FileAssetManager.entities.core(ce.kernel, tgt))
+
+        // TODO: In case there are no local ipcores, they are synth'ed prior to compose job, This is done LOCALLY
+        files ++ cores.map(_.get.zipPath) ++ cores.map(_.get.descPath)
+      }
+      case HighLevelSynthesisJob(_, _, _, k, _) => {
+        val kernels = FileAssetManager.entities.kernels.filter( kernel => k.get.contains(kernel.name) ).toSeq
+        files ++ kernels.map(_.descPath.getParent)
+      }
+      case _ => files
+    }
+
+    val remote_files = local_files map update_paths
+    file_transfer(local_files.zip(remote_files).toMap, tx = true)
+  }
+
+  /**
+    * Postamble is run after the SLURM job is finished.
+    * Copy generated artefacts back from the SLURM node.
+    * @param slurm_job  Job to execute.
+    * @param files List of (local) filenames that need to be copied from SLURM node to local machine
+    * @param update_paths Function that converts local workdir file paths to valid paths on a remote SLURM node.
+    **/
+  def slurm_postamble(slurm_job: Job, files: Seq[Path], update_paths: Path => Path): Unit = {
+    val loc_files = slurm_job.job match {
+      case ComposeJob(c, f, _, a, p, _, _, _, _, _) => {
+        val tgt = Target.fromString(a.get.head, p.get.head).get
+        val bit = slurm_job.log.resolveSibling( Composer.mkProjectName(c, tgt, f) + ".bit" )
+        val bin = slurm_job.log.resolveSibling( Composer.mkProjectName(c, tgt, f) + ".bit.bin" )
+
+        // TODO: Is this sufficient, or do we also need the timing/utilization report (or simply pull whole composition folder) ?
+        files ++ Seq(bit, bin)
+      }
+      case HighLevelSynthesisJob(_, a,p, kernels, _) => {
+        val tgt = Target.fromString(a.get.head, p.get.head).get
+        val cores = kernels.get.map(k => FileAssetManager.entities.core(k, tgt))
+        files ++ cores.map(_.get.zipPath) ++ cores.map(_.get.descPath)
+      }
+      case _ => files
+    }
+
+    val remote_files = loc_files map update_paths
+    file_transfer(remote_files.zip(loc_files).toMap, tx=false)
+  }
+
+  /**
+    * Copy a set of files either from a host to a remote SLURM node or vice versa, depending on the @param tx
+    * @param tfer A map from SRC to DST file paths
+    * @param tx indicates the direction of transfer. If value is true (false), the direction is push (pull).
+    **/
+  def file_transfer(tfer: Map[Path, Path], tx: Boolean): Boolean = {
+    for ((from, to) <- tfer) {
+      val target_host = slurm_remote_cfg.get.workstation;
+      logger.info("Copying %s to %s on %s".format(from, to, target_host))
+
+      // parent directory may not exist
+      exec_cmd("mkdir -p %s".format(to.getParent), hostname = Some(target_host))
+
+      val cpy_cmd = if (tx)
+        "scp -r %s %s:%s".format(from, target_host, to)
+      else
+        "scp -r %s:%s %s".format(target_host, from, to)
+      logger.info("Copy Command: " + cpy_cmd)
+      if (cpy_cmd.! != 0)  throw new Exception("Could not copy file %s to %s!".format(from, to))
+    }
+    true
+  }
+
+  /**
     * Schedules a job on SLURM.
     *
     * @param script Job script file to schedule via `sbatch`.

--- a/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
+++ b/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
@@ -46,11 +46,14 @@ final object Slurm extends Publisher {
                         /** Name of the job. */
                         name: String,
 
-                        /** File name of the stdout logfile. */
-                        slurmLog: String,
+                        /** File name of the tapasco logfile. */
+                        log: Path,
 
-                        /** File name of the stderr logfile. */
-                        errorLog: String,
+                        /** File name of the stdout slurm logfile. */
+                        slurmLog: Path,
+
+                        /** File name of the stderr slurm logfile. */
+                        errorLog: Path,
 
                         /** Consumer to schedule. */
                         consumer: ResourceConsumer,
@@ -62,7 +65,13 @@ final object Slurm extends Publisher {
                         commands: Seq[String],
 
                         /** Optional comment. */
-                        comment: Option[String] = None
+                        comment: Option[String] = None,
+
+                        /** The job to execute */
+                        job: tapasco.jobs.Job,
+
+                        /** Filename of the tapasco configuration file */
+                        cfg_file: Path
                       )
 
   /** Exception class for negative SLURM responses. */

--- a/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
+++ b/toolflow/scala/src/main/scala/tapasco/slurm/Slurm.scala
@@ -169,6 +169,8 @@ final object Slurm extends Publisher {
     jobScript("TAPASCO_HOME") = upd_wd(FileAssetManager.TAPASCO_WORK_DIR).toString
     jobScript("COMMANDS") = "tapasco --configFile %s".format(upd_wd(job.cfg_file).toString)
     jobScript("COMMENT") = job.comment getOrElse ""
+    if (slurm_remote_cfg.isDefined)
+      jobScript("WORKSTATION") = slurm_remote_cfg.get.workstation
     // create parent directory
     Files.createDirectories(file.getParent())
     // write file

--- a/toolflow/vivado/common/SLURM/ESA.json
+++ b/toolflow/vivado/common/SLURM/ESA.json
@@ -1,0 +1,9 @@
+{
+	"Name" : "ESA Cluster",
+	"SlurmHost" : "slurm",
+	"WorkstationHost" : "balin",
+	"Workdir" : "/scratch/tapasco_workdir",
+	"TapascoInstallDir" : "/scratch/tapasco",
+	"JobFile" : "slurm_ESA.job.template"
+}
+

--- a/toolflow/vivado/common/SLURM/ESA.json
+++ b/toolflow/vivado/common/SLURM/ESA.json
@@ -2,8 +2,8 @@
 	"Name" : "ESA Cluster",
 	"SlurmHost" : "slurm",
 	"WorkstationHost" : "balin",
-	"Workdir" : "/scratch/tapasco_workdir",
-	"TapascoInstallDir" : "/scratch/tapasco",
+	"Workdir" : "/scratch/SLURM/tapasco_workdir",
+	"TapascoInstallDir" : "/scratch/SLURM/tapasco",
 	"JobFile" : "slurm_ESA.job.template"
 }
 

--- a/toolflow/vivado/common/SLURM/default.job.template
+++ b/toolflow/vivado/common/SLURM/default.job.template
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright (c) 2014-2020 Embedded Systems and Applications, TU Darmstadt.
+#
+# This file is part of TaPaSCo
+# (see https://github.com/esa-tu-darmstadt/tapasco).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+#SBATCH -J "@@JOB_NAME@@"
+#SBATCH -o "@@SLURM_LOG@@"
+#SBATCH -e "@@ERROR_LOG@@"
+#SBATCH --mem-per-cpu=@@MEM_PER_CPU@@
+#SBATCH -n @@CPUS@@
+#SBATCH -t @@TIMELIMIT@@
+#SBATCH --comment="@@COMMENT@@"
+
+source @@TAPASCO_HOME@@/tapasco-setup.sh
+
+# user commands begin here
+echo "SLURM job #$SLURM_JOB_ID started at $(date)"
+@@COMMANDS@@
+echo "SLURM job #$SLURM_JOB_ID finished at $(date)"

--- a/toolflow/vivado/common/SLURM/slurm_ESA.job.template
+++ b/toolflow/vivado/common/SLURM/slurm_ESA.job.template
@@ -26,7 +26,7 @@
 #SBATCH -t @@TIMELIMIT@@
 #SBATCH --comment="@@COMMENT@@"
 
-source @@TAPASCO_HOME@@/setup.sh
+source @@TAPASCO_HOME@@/tapasco-setup.sh
 
 # user commands begin here
 echo "SLURM job #$SLURM_JOB_ID started at $(date)"

--- a/toolflow/vivado/common/SLURM/slurm_ESA.job.template
+++ b/toolflow/vivado/common/SLURM/slurm_ESA.job.template
@@ -26,9 +26,13 @@
 #SBATCH -t @@TIMELIMIT@@
 #SBATCH --comment="@@COMMENT@@"
 
+# Setup env
 source @@TAPASCO_HOME@@/tapasco-setup.sh
+export PATH="/opt/cad/xilinx/vivado/Vivado/2019.2/bin/:$PATH"
 
 # user commands begin here
 echo "SLURM job #$SLURM_JOB_ID started at $(date)"
+rsync -a /net/@@WORKSTATION@@/SLURM/tapasco_workdir/ @@TAPASCO_HOME@@
 @@COMMANDS@@
+rsync -a @@TAPASCO_HOME@@/ /net/@@WORKSTATION@@/SLURM/tapasco_workdir
 echo "SLURM job #$SLURM_JOB_ID finished at $(date)"


### PR DESCRIPTION
This pull request extends the SLURM support of tapasco such that remote compute nodes can be used for carrying out HLS and compose jobs.

The required architecture consist of three networked machines:

- **Host** (front end):
Runs a tapasco instance that takes in the user CLI arguments and collects all required files for the selected job (e.g. kernel source files for HLS jobs or IPCores for compose jobs). These dependencies are copied over the network to a separate node referred to as `Workstation`. The artefacts that are generated by a job (e.g. IPCore for HLS, bitstream for compose) are copied back to the Host once the job finishes.

- **Workstation**:
In the simplest case a network attached storage. It is required, since in the general case we cannot directly push files to the SLURM compute node. Thus, the files are deposited in a known directory on this node, and the SLURM compute node can pull the files from here by itself.

- **SLURM node** (back end):
Login node to the compute node that has SLURM control tools such as `sbatch` and `squeue` installed. The compute node runs its own tapasco instance.

The above setup is configurable through a JSON config file. This PR contains an example file at `toolflow/vivado/common/SLURM/ESA.json` that describes an ESA internal compute node. Different configurations can be selected via tapasco CLI options at the Host, for example `--slurm ESA`.
