### PR TITLE
Fix a hardcoded value in Rust example libtapasco_tests

### DIFF
--- a/runtime/examples/Rust/libtapasco_tests/src/main.rs
+++ b/runtime/examples/Rust/libtapasco_tests/src/main.rs
@@ -327,7 +327,7 @@ fn test_copy(_: &ArgMatches) -> Result<()> {
             let a = mem
                 .allocator()
                 .lock()?
-                .allocate(256 * 4)
+                .allocate(len as u64)
                 .context(AllocatorError)?;
 
             let mut golden_samples: Vec<u8> = Vec::new();


### PR DESCRIPTION
The function `test_copy` in `libtapasco_tests` allocates a constant 1024B of memory for each test iteration. For test vectors of length > 1024B this will result in illegal memory accesses.

This causes a Segfault in the userspace application and the following Kernel Oops:

```
[15397.213540] Unable to handle kernel paging request at virtual address ffffffc011392000
[15397.221458] Mem abort info:
[15397.224246]   ESR = 0x96000047
[15397.227295]   EC = 0x25: DABT (current EL), IL = 32 bits
[15397.232599]   SET = 0, FnV = 0
[15397.235653]   EA = 0, S1PTW = 0
[...]
```