### PR TITLE
Fix ordering in configuration serialization

### DIFF
--- a/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
+++ b/toolflow/scala/src/main/scala/tapasco/base/json/package.scala
@@ -422,8 +422,8 @@ package object json {
       (JsPath \ "Slurm").write[Boolean] ~
       (JsPath \ "Parallel").write[Boolean] ~
       (JsPath \ "MaxThreads").writeNullable[Int] ~
-      (JsPath \ "HlsTimeOut").writeNullable[Int] ~
       (JsPath \ "MaxTasks").writeNullable[Int] ~
+      (JsPath \ "HlsTimeOut").writeNullable[Int] ~
       (JsPath \ "DryRun").writeNullable[Path].transform((js: JsObject) => js - "DryRun") ~
       (JsPath \ "Verbose").writeNullable[String] ~
       (JsPath \ "Jobs").write[Seq[Job]]


### PR DESCRIPTION
Bug causes the `HlsTimeOut` property to be serialized as `MaxTasks`