### PR TITLE
PEs are now always wrapped before post-pe-create plugin

### DIFF
--- a/toolflow/vivado/arch/axi4mm/axi4mm.tcl
+++ b/toolflow/vivado/arch/axi4mm/axi4mm.tcl
@@ -99,8 +99,20 @@ namespace eval arch {
       puts "  VLNV: $vlnv"
       for {set j 0} {$j < $no_inst} {incr j} {
         set name [format "target_ip_%02d_%03d" $i $j]
-        set inst [lindex [tapasco::call_plugins "post-pe-create" [create_bd_cell -type ip -vlnv "$vlnv" $name]] 0]
-        lappend insts $inst
+
+        # Create PE instance
+        set inst [create_bd_cell -type ip -vlnv "$vlnv" "internal_$name"]
+        set bd_inst [current_bd_instance .]
+        # create group, move instance into group
+        set group [create_bd_cell -type hier $name]
+        move_bd_cells $group $inst
+
+        # Current bd instance is the wrapper around PE instance
+        current_bd_instance $group
+        set inst [lindex [tapasco::call_plugins "post-pe-create" $inst] 0]
+        current_bd_instance $bd_inst
+
+        lappend insts $group
       }
     }
     puts "insts = $insts"

--- a/toolflow/vivado/arch/axi4mm/axi4mm.tcl
+++ b/toolflow/vivado/arch/axi4mm/axi4mm.tcl
@@ -98,21 +98,26 @@ namespace eval arch {
       puts "Creating $no_inst instances of target IP core ..."
       puts "  VLNV: $vlnv"
       for {set j 0} {$j < $no_inst} {incr j} {
-        set name [format "target_ip_%02d_%03d" $i $j]
-
         # Create PE instance
+        set name [format "target_ip_%02d_%03d" $i $j]
         set inst [create_bd_cell -type ip -vlnv "$vlnv" "internal_$name"]
-        set bd_inst [current_bd_instance .]
-        # create group, move instance into group
-        set group [create_bd_cell -type hier $name]
-        move_bd_cells $group $inst
 
-        # Current bd instance is the wrapper around PE instance
-        current_bd_instance $group
-        set inst [lindex [tapasco::call_plugins "post-pe-create" $inst] 0]
-        current_bd_instance $bd_inst
+        # Only create a wrapper around PEs if atleast one plugin is present
+        if {[llength [tapasco::get_plugins "post-pe-create"]] > 0} {
+          set bd_inst [current_bd_instance .]
+          # create group, move instance into group
+          set group [create_bd_cell -type hier $name]
+          move_bd_cells $group $inst
 
-        lappend insts $group
+          # Current bd instance is the wrapper around PE instance
+          current_bd_instance $group
+          set inst [lindex [tapasco::call_plugins "post-pe-create" $inst] 0]
+          current_bd_instance $bd_inst
+
+          lappend insts $group
+        } else {
+          lappend insts $inst
+        }
       }
     }
     puts "insts = $insts"


### PR DESCRIPTION
The full_axi_slave_wrapper post-pe-create plugin was
wrapping a PE to insert a AXI lite to AXI full converter.
This creates a problem for other post-pe-create plugins.
Especially since the order in which post-pe-create
plugins are executed is deterministic.

This commit changes that a PE is now always wrapped. All
post-pe-create plugins now have the same starting
conditions. They also always have to return the PE so that
following plugins have access to them.