### PR TITLE
Improve systemcache

### DIFF
--- a/toolflow/vivado/platform/AU280/AU280.tcl
+++ b/toolflow/vivado/platform/AU280/AU280.tcl
@@ -174,6 +174,7 @@ namespace eval platform {
     insert_regslice "host_dma" true "/host/M_DMA" "/memory/S_DMA" "/clocks_and_resets/host_clk" "/clocks_and_resets/host_interconnect_aresetn" ""
     insert_regslice "dma_host" true "/memory/M_HOST" "/host/S_HOST" "/clocks_and_resets/host_clk" "/clocks_and_resets/host_interconnect_aresetn" ""
     insert_regslice "host_arch" true "/host/M_ARCH" "/arch/S_ARCH" "/clocks_and_resets/design_clk" "/clocks_and_resets/design_interconnect_aresetn" ""
+    insert_regslice "l2_cache" [tapasco::is_feature_enabled "Cache"] "/memory/cache_l2_0/M0_AXI" "/memory/mig/C0_DDR4_S_AXI" "/clocks_and_resets/mem_clk" "/clocks_and_resets/mem_peripheral_aresetn" "/memory"
 
     if {[is_regslice_enabled "pe" false]} {
       set ips [get_bd_cells /arch/target_ip_*]

--- a/toolflow/vivado/platform/AU280/plugins/hbm.tcl
+++ b/toolflow/vivado/platform/AU280/plugins/hbm.tcl
@@ -245,17 +245,17 @@ namespace eval hbm {
 
         set hbm_index [format %02s $i]
 
-        # create smartconnect for clock domain conversion, protocol conversion (AXI4->AXI3) and data width conversion
-        set converter [create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect:1.0 smartconnect_${i}]
-        set_property -dict [list CONFIG.NUM_SI {1} CONFIG.NUM_CLKS {2} CONFIG.HAS_ARESETN {0}] $converter
+        # create interconnect for clock domain conversion, protocol conversion (AXI4->AXI3) and data width conversion
+        set converter [tapasco::ip::create_axi_ic converter_ic_${i} 1 1]
         
-        # create connections between PE and smartconnect, and smartconnect and HBM
-
-        connect_bd_net [get_bd_pins design_clk] [get_bd_pins $converter/aclk]
-        connect_bd_net [get_bd_pins $hbm/AXI_${hbm_index}_ACLK] [get_bd_pins $converter/aclk1]
+        # create connections between PE and interconnect, and interconnect and HBM
+        connect_bd_net [get_bd_pins design_clk] [get_bd_pins $converter/S00_ACLK]
+        connect_bd_net [get_bd_pins design_interconnect_aresetn] [get_bd_pins $converter/S00_ARESETN]
+        connect_bd_net [get_bd_pins $hbm/AXI_${hbm_index}_ACLK] [get_bd_pins $converter/ACLK] [get_bd_pins $converter/M00_ACLK]
+        connect_bd_net [get_bd_pins $hbm/AXI_${hbm_index}_ARESET_N] [get_bd_pins $converter/ARESETN] [get_bd_pins $converter/M00_ARESETN]
 
         if {[platform::is_regslice_enabled "hbm_pe" false] || [platform::is_regslice_enabled [format "hbm_pe%s" $hbm_index] false]} {
-          # insert register slice between PE and smartconnect
+          # insert register slice between PE and interconnect
           set regslice_pre [create_bd_cell -type ip -vlnv xilinx.com:ip:axi_register_slice:2.1 regslice_pre_${i}]
           set_property -dict [list CONFIG.REG_AW {15} CONFIG.REG_AR {15} CONFIG.REG_W {15} CONFIG.REG_R {15} CONFIG.REG_B {15} CONFIG.USE_AUTOPIPELINING {1}] $regslice_pre
 
@@ -269,7 +269,7 @@ namespace eval hbm {
         }
 
         if {[platform::is_regslice_enabled "hbm_hbm" false] || [platform::is_regslice_enabled [format "hbm_hbm%s" $hbm_index] false]} {
-          # insert register slice between smartconnect and HBM
+          # insert register slice between interconnect and HBM
           set regslice_post [create_bd_cell -type ip -vlnv xilinx.com:ip:axi_register_slice:2.1 regslice_post_${i}]
           set_property -dict [list CONFIG.REG_AW {15} CONFIG.REG_AR {15} CONFIG.REG_W {15} CONFIG.REG_R {15} CONFIG.REG_B {15} CONFIG.USE_AUTOPIPELINING {1}] $regslice_post
 

--- a/toolflow/vivado/platform/AU280/plugins/hbm.tcl
+++ b/toolflow/vivado/platform/AU280/plugins/hbm.tcl
@@ -361,7 +361,7 @@ if {[tapasco::is_feature_enabled "HBM"]} {
 			current_bd_instance $subsystem
 			set clock [tapasco::subsystem::get_port "design" "clk"]
 			set reset [tapasco::subsystem::get_port "design" "rst" "peripheral" "resetn"]
-			current_bd_instance $subsystem
+			current_bd_instance $instance
 
 			# existing memory controller cache location
 			set cons [list [get_bd_intf_pins /memory/mig_ic/M00_AXI] [get_bd_intf_pins -regexp /memory/mig/(C0_DDR4_)?S_AXI] "/memory" [tapasco::subsystem::get_port "mem" "clk"] [tapasco::subsystem::get_port "mem" "rst" "peripheral" "resetn"]]

--- a/toolflow/vivado/platform/common/plugins/system_cache.tcl
+++ b/toolflow/vivado/platform/common/plugins/system_cache.tcl
@@ -31,8 +31,10 @@ namespace eval system_cache {
 				set cache [tapasco::ip::create_axi_cache "cache_l2_$i" 1 \
 				  [tapasco::get_feature_option "Cache" "size" 32768] \
 				  [tapasco::get_feature_option "Cache" "associativity" 2]]
-				# set slave port width to 512bit, otherwise uses (not working) width conversion in SmartConnect
-				set_property CONFIG.C_S0_AXI_GEN_DATA_WIDTH {512} $cache
+				if {[get_property CONFIG.DATA_WIDTH $platform_port] > 32} {
+					# set slave port width to 512bit, otherwise uses (not working) width conversion in SmartConnect
+					set_property CONFIG.C_S0_AXI_GEN_DATA_WIDTH [get_property CONFIG.DATA_WIDTH $platform_port] $cache
+				}
 				if {[tapasco::get_feature_option "Cache" "force_allocate_read"]} {
 					# force caching for master (otherwise relies on axi cache signals)
 					puts "  Force allocate read"

--- a/toolflow/vivado/platform/common/plugins/system_cache.tcl
+++ b/toolflow/vivado/platform/common/plugins/system_cache.tcl
@@ -22,49 +22,50 @@ namespace eval system_cache {
 	proc create_system_cache {} {
 		if {[tapasco::is_feature_enabled "Cache"]} {
 			set instance [current_bd_instance]
-			current_bd_instance /memory
 			set cf [tapasco::get_feature "Cache"]
 			puts "Platform configured w/L2 Cache, implementing ..."
-			set cache [tapasco::ip::create_axi_cache "cache_l2" 1 \
-			  [tapasco::get_feature_option "Cache" "size" 32768] \
-			  [tapasco::get_feature_option "Cache" "associativity" 2]]
-			# set slave port width to 512bit, otherwise uses (not working) width conversion in SmartConnect
-			set_property CONFIG.C_S0_AXI_GEN_DATA_WIDTH {512} $cache
-			if {[tapasco::get_feature_option "Cache" "force_allocate_read"]} {
-				# force caching for master (otherwise relies on axi cache signals)
-				puts "  Force allocate read"
-				set_property CONFIG.C_S0_AXI_GEN_FORCE_READ_ALLOCATE 1 $cache
-				set_property CONFIG.C_S0_AXI_GEN_FORCE_READ_BUFFER 1 $cache
+			set i 0
+			foreach {platform_port memory_port subsystem clock reset} [get_mem_connections] {
+				puts "  Inserting cache between $platform_port and $memory_port in subsystem $subsystem"
+				current_bd_instance $subsystem
+				set cache [tapasco::ip::create_axi_cache "cache_l2_$i" 1 \
+				  [tapasco::get_feature_option "Cache" "size" 32768] \
+				  [tapasco::get_feature_option "Cache" "associativity" 2]]
+				# set slave port width to 512bit, otherwise uses (not working) width conversion in SmartConnect
+				set_property CONFIG.C_S0_AXI_GEN_DATA_WIDTH {512} $cache
+				if {[tapasco::get_feature_option "Cache" "force_allocate_read"]} {
+					# force caching for master (otherwise relies on axi cache signals)
+					puts "  Force allocate read"
+					set_property CONFIG.C_S0_AXI_GEN_FORCE_READ_ALLOCATE 1 $cache
+					set_property CONFIG.C_S0_AXI_GEN_FORCE_READ_BUFFER 1 $cache
+				}
+				if {[tapasco::get_feature_option "Cache" "force_allocate_write"]} {
+					puts "  Force allocate write"
+					set_property CONFIG.C_S0_AXI_GEN_FORCE_WRITE_ALLOCATE 1 $cache
+					set_property CONFIG.C_S0_AXI_GEN_FORCE_WRITE_BUFFER 1 $cache
+				}
+
+				# remove existing connection
+				delete_bd_objs [get_bd_intf_nets -of_objects $memory_port]
+				# connect mig_ic master to cache_l2
+				connect_bd_intf_net $platform_port [get_bd_intf_pins $cache/S0_AXI_GEN]
+				# connect cache_l2 to MIG
+				connect_bd_intf_net [get_bd_intf_pins $cache/M0_AXI] $memory_port
+
+				# connect clocks and reset
+				connect_bd_net $clock [get_bd_pins $cache/ACLK]
+				connect_bd_net $reset [get_bd_pins $cache/ARESETN]
+				incr i
 			}
-			if {[tapasco::get_feature_option "Cache" "force_allocate_write"]} {
-				puts "  Force allocate write"
-				set_property CONFIG.C_S0_AXI_GEN_FORCE_WRITE_ALLOCATE 1 $cache
-				set_property CONFIG.C_S0_AXI_GEN_FORCE_WRITE_BUFFER 1 $cache
-			}
-
-			# remove existing connection
-			delete_bd_objs [get_bd_intf_nets -of_objects [get_memory_port]]
-			# connect mig_ic master to cache_l2
-			connect_bd_intf_net [get_platform_port] [get_bd_intf_pins $cache/S0_AXI_GEN]
-			# connect cache_l2 to MIG
-			connect_bd_intf_net [get_bd_intf_pins $cache/M0_AXI] [get_memory_port]
-
-			# connect clocks and reset
-			connect_bd_net [tapasco::subsystem::get_port "mem" "clk"] [get_bd_pins $cache/ACLK]
-			connect_bd_net [tapasco::subsystem::get_port "mem" "rst" "peripheral" "resetn"] [get_bd_pins $cache/ARESETN]
-
 			current_bd_instance $instance
 		}
 		return {}
 	}
 
-	proc get_memory_port {} {
-		error "Cache feature not implemented for this platform"
-	}
-
-	proc get_platform_port {} {
+	proc get_mem_connections {} {
 		error "Cache feature not implemented for this platform"
 	}
 }
 
 tapasco::register_plugin "platform::system_cache::create_system_cache" "post-platform"
+

--- a/toolflow/vivado/platform/pcie/plugins/system_cache.tcl
+++ b/toolflow/vivado/platform/pcie/plugins/system_cache.tcl
@@ -25,7 +25,7 @@ namespace eval system_cache {
 		current_bd_instance $subsystem
 		set clock [tapasco::subsystem::get_port "mem" "clk"]
 		set reset [tapasco::subsystem::get_port "mem" "rst" "peripheral" "resetn"]
-		current_bd_instance $subsystem
+		current_bd_instance $instance
 		return [list [get_bd_intf_pins /memory/mig_ic/M00_AXI] [get_bd_intf_pins -regexp /memory/mig/(C0_DDR4_)?S_AXI] $subsystem $clock $reset]
 	}
 }

--- a/toolflow/vivado/platform/pcie/plugins/system_cache.tcl
+++ b/toolflow/vivado/platform/pcie/plugins/system_cache.tcl
@@ -18,11 +18,14 @@
 #
 
 namespace eval system_cache {
-	proc get_platform_port {} {
-		return [get_bd_intf_pins mig_ic/M00_AXI]
-	}
 
-	proc get_memory_port {} {
-		return [get_bd_intf_pins -regexp mig/(C0_DDR4_)?S_AXI]
+	proc get_mem_connections {} {
+		set subsystem "/memory"
+		set instance [current_bd_instance]
+		current_bd_instance $subsystem
+		set clock [tapasco::subsystem::get_port "mem" "clk"]
+		set reset [tapasco::subsystem::get_port "mem" "rst" "peripheral" "resetn"]
+		current_bd_instance $subsystem
+		return [list [get_bd_intf_pins /memory/mig_ic/M00_AXI] [get_bd_intf_pins -regexp /memory/mig/(C0_DDR4_)?S_AXI] $subsystem $clock $reset]
 	}
 }


### PR DESCRIPTION
Support multiple system caches within a composition. This is implemented for HBM on the Alveo U280, which then can have a cache for each HBM memory port.