### PR TITLE
Fix HBM

### DIFF
--- a/toolflow/vivado/platform/AU280/plugins/hbm.tcl
+++ b/toolflow/vivado/platform/AU280/plugins/hbm.tcl
@@ -17,7 +17,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-
 if {[tapasco::is_feature_enabled "HBM"]} {
   proc create_custom_subsystem_hbm {{args {}}} {
 
@@ -291,8 +290,13 @@ namespace eval hbm {
       set masters [ldiff [lsort -dictionary [tapasco::get_aximm_interfaces [get_bd_cells /arch/target_ip_*]]] $hbmInterfaces]
       set arch_mem_ics [arch::arch_create_mem_interconnects $mgroups [llength $masters]]
       arch::arch_connect_mem $arch_mem_ics $masters
-      catch {arch::arch_connect_clocks} issue
-      catch {arch::arch_connect_resets} issue
+      
+      connect_bd_net [tapasco::subsystem::get_port "design" "clk"] \
+        [get_bd_pins -of_objects [get_bd_cells] -filter "TYPE == clk && DIR == I"]
+      connect_bd_net -quiet [tapasco::subsystem::get_port "design" "rst" "interconnect"] \
+        [get_bd_pins -of_objects [get_bd_cells] -filter "TYPE == rst && NAME =~ *interconnect_aresetn && DIR == I"]
+      connect_bd_net [tapasco::subsystem::get_port "design" "rst" "peripheral" "resetn"] \
+        [get_bd_pins -of_objects [get_bd_cells -of_objects [current_bd_instance .]] -filter "TYPE == rst && NAME =~ *peripheral_aresetn && DIR == I"]
 
       # apply constraints for one or both stacks
       current_bd_instance /hbm


### PR DESCRIPTION
The HBM feature was broken with the PE Wrapper fix (#281) when not all PEs are connected to HBM.
This fixes it by correctly connecting the clock and resets of the Interconnect for the non-HBM-connected PEs