### PR TITLE
Extend libtapasco with Monitor DMA Engine

### DIFF
--- a/runtime/libtapasco/src/dma.rs
+++ b/runtime/libtapasco/src/dma.rs
@@ -278,3 +278,23 @@ impl DMAControl for DirectDMA {
         Ok(())
     }
 }
+
+
+/// Use MonitorDMA for applications that only monitor other applications like tapasco-debug
+/// This implementation simply does nothing
+#[derive(Debug)]
+pub struct MonitorDMA;
+
+impl DMAControl for MonitorDMA {
+    fn copy_to(&self, _data: &[u8], _ptr: DeviceAddress) -> Result<()> {
+        trace!("MonitorDMA copy_to: Doing nothing.");
+
+        Ok(())
+    }
+
+    fn copy_from(&self, _ptr: DeviceAddress, _data: &mut [u8]) -> Result<()> {
+        trace!("MonitorDMA copy_to: Doing nothing.");
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Implement suggestion of @jahofmann in:
https://github.com/esa-tu-darmstadt/tapasco/issues/296#issuecomment-900076385

When a new device is created a dummy implementation of the DMA Engine is
used that simply does nothing. The actual DMA Engine is initialized
later when the access mode is changed from monitor to exclusive mode.

This is necessary to prevent a monitoring application like
`tapasco-debug` to allocate all DMA Buffers of the kernel driver.