### PR TITLE
[feature] Build TLKM in Tapasco workspace

### DIFF
--- a/runtime/bin/tapasco-build-libs
+++ b/runtime/bin/tapasco-build-libs
@@ -26,7 +26,7 @@ from socket import gethostname
 import os
 
 default_cmd = 'mkdir -p {0} && cd {0} && cmake {1} {2} && make -j $(nproc) install DESTDIR={0}/install'
-tlkm_cmd = 'cd {0} && make -j $(nproc) {1} {2}'
+tlkm_cmd = 'mkdir -p {0} && cd {0} && cp -a {1} ./tlkm && cd ./tlkm && make -j $(nproc) {2} {3}'
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -113,7 +113,7 @@ if not clean:
 
     if not args.skip_driver:
         ret = subprocess.call(
-            [tlkm_cmd.format(mdir, '' if driver_debug else 'release', 'EN_SVM=1' if args.enable_svm else '')], shell=True)
+            [tlkm_cmd.format(bdir, mdir, '' if driver_debug else 'release', 'EN_SVM=1' if args.enable_svm else '')], shell=True)
         if ret:
             print('Driver build failed!')
             sys.exit(ret)

--- a/runtime/scripts/f1/bit_reload.sh
+++ b/runtime/scripts/f1/bit_reload.sh
@@ -21,7 +21,7 @@
 
 # init paths
 DRIVER=tlkm
-DRIVERPATH="$TAPASCO_HOME_RUNTIME/kernel"
+DRIVERPATH="$TAPASCO_WORK_DIR/build/tlkm"
 
 show_usage() {
 	cat << EOF

--- a/runtime/scripts/pcie/bit_reload.sh
+++ b/runtime/scripts/pcie/bit_reload.sh
@@ -27,7 +27,7 @@ set -e
 
 # init paths
 DRIVER=tlkm
-DRIVERPATH="$TAPASCO_HOME_RUNTIME/kernel"
+DRIVERPATH="$TAPASCO_WORK_DIR/build/tlkm"
 BITLOAD_SCRIPT="$TAPASCO_HOME_RUNTIME/scripts/pcie/program_pcie.tcl"
 LOG_ID=$DRIVER"|""pci"
 

--- a/runtime/scripts/zynq/bit_reload.sh
+++ b/runtime/scripts/zynq/bit_reload.sh
@@ -31,7 +31,7 @@ set -e
 
 # init paths
 DRIVER=tlkm
-DRIVERPATH="$TAPASCO_HOME_RUNTIME/kernel"
+DRIVERPATH="$TAPASCO_WORK_DIR/build/tlkm"
 VFIO_RST_REQ="/sys/module/vfio_platform/parameters/reset_required"
 VFIO_UNSAFE_INTR="/sys/module/vfio_iommu_type1/parameters/allow_unsafe_interrupts"
 


### PR DESCRIPTION
This modifies `tapasco-build-libs` to make the kernel module inside the
build directory of the tapasco workspace instead of the repository where
the source code is located.
Also, the scripts to load a bitstream are changed to use the new path
for the kernel object.