### PR TITLE
Modify libtapasco to allow explicit waiting for PE

### DIFF
--- a/runtime/libtapasco/src/job.rs
+++ b/runtime/libtapasco/src/job.rs
@@ -286,6 +286,15 @@ impl Job {
         Ok(unused_mem)
     }
 
+    /// Just wait for a PE's completion. Useful for measuring execution time.
+    pub fn wait_for_completion(&mut self) -> Result<()> {
+        if self.pe.is_some() {
+            self.pe.as_mut().unwrap().wait_for_completion().context(PEError)
+        } else {
+            Err(Error::NoPEtoRelease {})
+        }
+    }
+
     /// Wait for job completion and handle copy back if necessary.
     ///
     /// # Arguments

--- a/runtime/libtapasco/src/pe.rs
+++ b/runtime/libtapasco/src/pe.rs
@@ -170,7 +170,7 @@ impl PE {
     }
 
     /// Waits for a PE interrupt and deactivates the PE afterwards
-    fn wait_for_completion(&mut self) -> Result<()> {
+    pub fn wait_for_completion(&mut self) -> Result<()> {
         if self.active {
             self.interrupt
                 .wait_for_interrupt()


### PR DESCRIPTION
This is useful for measuring the communication overhead of a PE.