### PR TITLE
plugin hooks for ipec

### DIFF
--- a/toolflow/vivado/arch/axi4mm/axi4mm.tcl
+++ b/toolflow/vivado/arch/axi4mm/axi4mm.tcl
@@ -387,6 +387,11 @@ namespace eval arch {
 
   # Instantiates the architecture.
   proc create {{mgroups 0}} {
+    if {[tapasco::is_feature_enabled "IPEC"]} {
+      tapasco::call_plugins "ipec_blockdesign"
+      return
+    }
+
     variable arch_mem_ics
     variable arch_host_ics
 

--- a/toolflow/vivado/arch/axi4mm/plugins/full_axi_slave_wrapper.tcl
+++ b/toolflow/vivado/arch/axi4mm/plugins/full_axi_slave_wrapper.tcl
@@ -47,6 +47,9 @@ namespace eval full_axi_wrapper {
   }
 
   proc fix_address_map {args} {
+    if {[tapasco::is_feature_enabled "IPEC"]} {
+      return $args
+    }
     assign_bd_address
     return $args
   }

--- a/toolflow/vivado/common/design.master.tcl.template
+++ b/toolflow/vivado/common/design.master.tcl.template
@@ -40,6 +40,12 @@ tapasco::call_plugins "pre-header"
 source -notrace "$env(TAPASCO_HOME_TCL)/arch/common/arch.tcl"
 source -notrace @@ARCHITECTURE_TCL@@
 
+if {[tapasco::is_feature_enabled "IPEC"]} {
+  # source ipec
+  set feature [tapasco::get_feature "IPEC"]
+  source -notrace [dict get $feature "path"]
+}
+
 # source platform-specific Tcl scripts
 source -notrace "$env(TAPASCO_HOME_TCL)/platform/common/platform.tcl"
 source -notrace @@PLATFORM_TCL@@

--- a/toolflow/vivado/common/ip.tcl
+++ b/toolflow/vivado/common/ip.tcl
@@ -531,6 +531,9 @@ namespace eval ::tapasco::ip {
     set slots [list]
     set slot_id 0
     puts "  address map = $addr"
+    if {[tapasco::is_feature_enabled "IPEC"]} {
+      set slots [tapasco::call_plugins "ipec_statuscore" $slots]
+    }
     foreach intf [dict keys $addr] {
       if {[string match "/arch/*" "$intf"] == 1} {
         puts "  processing $intf: [dict get $addr $intf kind] ..."

--- a/toolflow/vivado/platform/AU280/plugins/hbm.tcl
+++ b/toolflow/vivado/platform/AU280/plugins/hbm.tcl
@@ -40,6 +40,10 @@ namespace eval hbm {
   proc get_hbm_interfaces {} {
     set hbmInterfaces [list]
 
+	if {[tapasco::is_feature_enabled "IPEC"]} {
+		return [tapasco::call_plugins "ipec_hbm"]
+	}
+
     set hbm [tapasco::get_feature "HBM"]
 
     set value [dict values [dict remove $hbm enabled]]
@@ -233,8 +237,10 @@ namespace eval hbm {
       }
 
       # remove standard memory interconnect network
-      delete_bd_objs [get_bd_cells /arch/out_*]
-      delete_bd_objs [get_bd_intf_pins /arch/M_MEM_*]
+      if {[tapasco::is_feature_enabled "IPEC"]} {} else {
+        delete_bd_objs [get_bd_cells /arch/out_*]
+        delete_bd_objs [get_bd_intf_pins /arch/M_MEM_*]
+      }
 
       for {set i 0} {$i < $numInterfaces} {incr i} {
         variable master [lindex $hbmInterfaces $i]

--- a/toolflow/vivado/platform/common/addressmap.tcl
+++ b/toolflow/vivado/platform/common/addressmap.tcl
@@ -114,6 +114,7 @@ namespace eval addressmap {
   }
 
   proc construct_address_map {{map ""}} {
+    tapasco::call_plugins "ipec_addressmap"
     if {$map == ""} { set map [::platform::get_address_map [::platform::get_pe_base_address]] }
     set map [apply_address_map_mods $map]
     set ignored [::platform::get_ignored_segments]
@@ -132,6 +133,18 @@ namespace eval addressmap {
             if {[catch {dict get $map $intf}]} {
               if {[catch {dict get $map $sintf}]} {
                 puts "    neither $intf nor $sintf were found in address map for $seg: $::errorInfo"
+
+                if {[tapasco::is_feature_enabled "IPEC"]} {
+                  if {[string match "/arch/*" $space]} {
+                    puts "addressmap: skipping space $space handled by ipec"
+                    continue
+                  }
+                  if {[string match "/arch/*" $seg]} {
+                    puts "addressmap: skipping space $space handled by ipec"
+                    continue
+                  }
+                }
+
                 puts "    assuming internal connection, setting values as found in segment:"
                 set range  [get_property RANGE $seg]
                 if {$range eq ""} {


### PR DESCRIPTION
This changes the toolflow to be compatible with ipec.
Adds ipec plugin hooks and skips parts of the previous toolflow if the ipec feature was enabled by the user.