### PR TITLE
enable PEs with multiple reg/mem slave interfaces

### DIFF
--- a/toolflow/vivado/arch/axi4mm/axi4mm.tcl
+++ b/toolflow/vivado/arch/axi4mm/axi4mm.tcl
@@ -360,6 +360,7 @@ namespace eval arch {
           set intr_name "PE_${i}_${pe_sub_interrupt}"
           puts "Creating interrupt $intr_name"
           connect_bd_net $pin [::tapasco::ip::add_interrupt $intr_name "design"]
+          incr pe_sub_interrupt
       }
       incr i
     }

--- a/toolflow/vivado/arch/common/arch.tcl
+++ b/toolflow/vivado/arch/common/arch.tcl
@@ -84,9 +84,9 @@ namespace eval arch {
             set offset [next_valid_address $offset $range]
             ::platform::addressmap::add_processing_element [llength [dict keys $ret]] $offset $range
             if { $usage == "register" } {
-              dict set ret $intf "interface $intf [format "offset 0x%08x range 0x%08x" $offset $range] kind register subintf $i"
+              dict set ret $intf "interface $intf [format "offset 0x%08x range 0x%08x" $offset $range] kind register"
             } else {
-              dict set ret $intf "interface $intf [format "offset 0x%08x range 0x%08x" $offset $range] kind memory subintf $i"
+              dict set ret $intf "interface $intf [format "offset 0x%08x range 0x%08x" $offset $range] kind memory"
             }
             incr offset $range
           }

--- a/toolflow/vivado/arch/common/arch.tcl
+++ b/toolflow/vivado/arch/common/arch.tcl
@@ -69,7 +69,10 @@ namespace eval arch {
           }
         }
       } else {
-        # if there is more than one reg/mem interface, we assume that the user knows what they are doing and add them in the same order
+        # If there is more than one reg/mem interface, we add them in the same order as declared in the IP-XACT core.
+        # The current runtime uses the order to detect control-register-interface & memory-interface pairs.
+        # When a PE has multiple such interfaces, ordering them regs first, mems second leads to the runtime recognizing only one reg-memory pair.
+        # When using the same ordering as the IP-XACT core, the user can define which memory-interface belongs to a certain control-register-interface by ordering them accordingly.
         puts "  processing $pe registers and memories ..."
         set all_segs [lsort [get_bd_addr_segs $pe/*]]
         for {set i 0} {$i < [llength $all_segs]} {incr i} {

--- a/toolflow/vivado/common/ip.tcl
+++ b/toolflow/vivado/common/ip.tcl
@@ -540,14 +540,13 @@ namespace eval ::tapasco::ip {
             set kid [dict get [::tapasco::get_composition] $kind id]
             set vlnv [dict get [::tapasco::get_composition] $kind vlnv]
 
-            if {[tapasco::is_feature_enabled "IPEC"]} {
-              set feature [tapasco::get_feature "IPEC"]
-              if {[dict exists $feature $vlnv]} {
-                set subintf [dict get $addr $intf "subintf"]
-                set kid [lindex [dict get $feature $vlnv "kid"] $subintf]
-                set kid [expr int($kid)]
-                set vlnv [lindex [dict get $feature $vlnv "vlnv"] $subintf]
-              }
+            set ipecfeature [tapasco::get_feature "IPEC"]
+			set intfname [lindex [split $intf /] end]
+            if {[dict exists $ipecfeature $vlnv $intfname]} {
+              set kid [dict get $ipecfeature $vlnv $intfname "kid"]
+              set kid [expr int($kid)]
+              set vlnv [dict get $ipecfeature $vlnv $intfname "vlnv"]
+              puts "  replaced vlnv $vlnv kid $kid"
             }
 
             lappend slots [json::write object "Type" [json::write string "Kernel"] "SlotId" $slot_id "Kernel" $kid \

--- a/toolflow/vivado/common/ip.tcl
+++ b/toolflow/vivado/common/ip.tcl
@@ -540,14 +540,11 @@ namespace eval ::tapasco::ip {
             set kid [dict get [::tapasco::get_composition] $kind id]
             set vlnv [dict get [::tapasco::get_composition] $kind vlnv]
 
-            set ipecfeature [tapasco::get_feature "IPEC"]
-            set intfname [lindex [split $intf /] end]
-            if {[dict exists $ipecfeature $vlnv $intfname]} {
-              set kid [dict get $ipecfeature $vlnv $intfname "kid"]
-              set kid [expr int($kid)]
-              set vlnv [dict get $ipecfeature $vlnv $intfname "vlnv"]
-              puts "  replaced vlnv $vlnv kid $kid"
-            }
+		    set intfinfo [tapasco::call_plugins "status-core-interface" $vlnv $intf]
+		    if { $intfinfo != {} } {
+				set kid  [lindex $intfinfo 0]
+				set vlnv [lindex $intfinfo 1]
+			}
 
             lappend slots [json::write object "Type" [json::write string "Kernel"] "SlotId" $slot_id "Kernel" $kid \
                                               "Offset" [json::write string [format "0x%016x" [expr "[dict get $addr $intf "offset"] - [::platform::get_pe_base_address]"]]]          \

--- a/toolflow/vivado/common/ip.tcl
+++ b/toolflow/vivado/common/ip.tcl
@@ -541,7 +541,7 @@ namespace eval ::tapasco::ip {
             set vlnv [dict get [::tapasco::get_composition] $kind vlnv]
 
             set ipecfeature [tapasco::get_feature "IPEC"]
-			set intfname [lindex [split $intf /] end]
+            set intfname [lindex [split $intf /] end]
             if {[dict exists $ipecfeature $vlnv $intfname]} {
               set kid [dict get $ipecfeature $vlnv $intfname "kid"]
               set kid [expr int($kid)]

--- a/toolflow/vivado/common/ip.tcl
+++ b/toolflow/vivado/common/ip.tcl
@@ -540,6 +540,16 @@ namespace eval ::tapasco::ip {
             set kid [dict get [::tapasco::get_composition] $kind id]
             set vlnv [dict get [::tapasco::get_composition] $kind vlnv]
 
+            if {[tapasco::is_feature_enabled "IPEC"]} {
+              set feature [tapasco::get_feature "IPEC"]
+              if {[dict exists $feature $vlnv]} {
+                set subintf [dict get $addr $intf "subintf"]
+                set kid [lindex [dict get $feature $vlnv "kid"] $subintf]
+                set kid [expr int($kid)]
+                set vlnv [lindex [dict get $feature $vlnv "vlnv"] $subintf]
+              }
+            }
+
             lappend slots [json::write object "Type" [json::write string "Kernel"] "SlotId" $slot_id "Kernel" $kid \
                                               "Offset" [json::write string [format "0x%016x" [expr "[dict get $addr $intf "offset"] - [::platform::get_pe_base_address]"]]]          \
                                               "Size" [json::write string [format "0x%016x" [dict get $addr $intf "range"]]] \

--- a/toolflow/vivado/platform/common/plugins/status_core_interface.tcl
+++ b/toolflow/vivado/platform/common/plugins/status_core_interface.tcl
@@ -1,0 +1,37 @@
+# Copyright (c) 2014-2020 Embedded Systems and Applications, TU Darmstadt.
+#
+# This file is part of TaPaSCo
+# (see https://github.com/esa-tu-darmstadt/tapasco).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+namespace eval status_core_interface {
+
+  proc get_interface_info { vlnv intf } {
+    set intf_rename [tapasco::get_feature "IPEC"]
+    set intfname [lindex [split $intf /] end]
+    if {[dict exists $intf_rename $vlnv $intfname]} {
+      set kid [dict get $intf_rename $vlnv $intfname "kid"]
+      set kid [expr int($kid)]
+      set vlnv [dict get $intf_rename $vlnv $intfname "vlnv"]
+      puts "  replaced vlnv $vlnv kid $kid"
+      return [list $kid $vlnv]
+    }
+    return {}
+  }
+
+}
+
+tapasco::register_plugin "platform::status_core_interface::get_interface_info" "status-core-interface"


### PR DESCRIPTION
when a PE has more than one reg slave or mem slave, tapasco can only use the first reg slave.
This allows a feature-declaration to allow for PEs width many such interfaces.