### PR TITLE
Add list of acquired devices to miscdev

### DIFF
--- a/runtime/kernel/tlkm/tlkm_ioctl.h
+++ b/runtime/kernel/tlkm/tlkm_ioctl.h
@@ -22,10 +22,15 @@
 
 #include <linux/fs.h>
 
-typedef struct {
+struct tlkm_ioctl_dev_list_head {
+	struct list_head head;
+};
+
+struct tlkm_ioctl_dev_list_entry {
+	struct list_head list;
 	struct tlkm_device *pdev;
 	tlkm_access_t access;
-} tlkm_ioctl_data;
+};
 
 long tlkm_ioctl_ioctl(struct file *fp, unsigned int ioctl, unsigned long data);
 


### PR DESCRIPTION
Track all opened devices in a list. This is required if an application uses more than one device in parallel. In the current implementation only the last acquired device is saved in the miscdev, and when closing the device file in the user-space runtime, only acceses to this single device is released. By tracking all acquired devices in a list, all devices are released properly when closing the miscdev.