### PR TITLE
Automize Evaluation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -403,6 +403,7 @@ tapasco_compose_ubuntu:
     - dnf -y install which unzip git zip tar findutils libX11 gcc gcc-c++ python3 glibc-langpack-en
     - ln -s /lib64/libtinfo.so.6 /lib64/libtinfo.so.5
   script:
+    - export LC_ALL=en_US.UTF-8
     - source $XILINX_VIVADO/settings64.sh
     - which vivado
     - which vivado_hls || which vitis_hls

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -409,8 +409,8 @@ tapasco_compose_ubuntu:
     - dnf -y install toolflow/scala/build/distributions/tapasco-2022-01.x86_64.rpm
     - /opt/tapasco/tapasco-init-toolflow.sh
     - source tapasco-setup-toolflow.sh
-    - tapasco hls arrayinit -p $PLATFORM --skipEvaluation
-    - tapasco import toolflow/examples/Counter.zip as 14 -p $PLATFORM --skipEvaluation
+    - tapasco hls arrayinit -p $PLATFORM
+    - tapasco import toolflow/examples/Counter.zip as 14 -p $PLATFORM
     - tapasco -v --maxThreads 3 compose [arrayinit x 2, Counter x 3] @ 100 MHz -p $PLATFORM $FLAGS
 
 tapasco_compose_17_4:

--- a/toolflow/scala/src/main/scala/tapasco/activity/Import.scala
+++ b/toolflow/scala/src/main/scala/tapasco/activity/Import.scala
@@ -56,7 +56,7 @@ object Import {
     * @param t             Target Architecture + Platform combination to import for.
     * @param acc           Average clock cycle count for a job execution on the PE (optional).
     * @param runEvaluation Do not perform out-of-context synthesis for resource estimation (optional).
-    * @param cfg           Implicit [[base.Configuration]].
+    * @param cfg           Implicit [[Configuration]].
     **/
   def apply(zip: Path, id: Kernel.Id, t: Target, acc: Option[Long], runEvaluation: Option[Boolean],
             optimization: Int, synthOptions: Option[String] = None)

--- a/toolflow/scala/src/main/scala/tapasco/activity/Import.scala
+++ b/toolflow/scala/src/main/scala/tapasco/activity/Import.scala
@@ -84,11 +84,11 @@ object Import {
     * Imports the IP-XACT .zip to the default path structure (ipcore/) and performs
     * out-of-context synthesis (if no report from HLS was found and skipEval was not set).
     *
-    * @param c        Core description.
-    * @param t        Target platform and architecture.
-    * @param p        Output path for core description file.
-    * @param skipEval Skip out-of-context synthesis step (optional).
-    * @param cfg      Implicit [[Configuration]].
+    * @param c              Core description.
+    * @param t              Target platform and architecture.
+    * @param p              Output path for core description file.
+    * @param runEvaluation  Run out-of-context synthesis step (optional).
+    * @param cfg            Implicit [[Configuration]].
     **/
   private def importCore(c: Core, t: Target, p: Path, vlnv: VLNV, runEvaluation: Option[Boolean], optimization: Int,
                          synthOptions: Option[String])

--- a/toolflow/scala/src/main/scala/tapasco/jobs/Jobs.scala
+++ b/toolflow/scala/src/main/scala/tapasco/jobs/Jobs.scala
@@ -203,13 +203,14 @@ final case class DesignSpaceExplorationJob(
   * @param _architectures  Name list of [[tapasco.base.Architecture]] instances.
   * @param _platforms      Name list of [[tapasco.base.Platform]] instances.
   * @param _kernels        Name list of [[tapasco.base.Kernel]] instances to synthesize.
+  * @param runEvaluation   Evaluate the Core.
   **/
 final case class HighLevelSynthesisJob(
                                         private val _implementation: String,
                                         private val _architectures: Option[Seq[String]] = None,
                                         private val _platforms: Option[Seq[String]] = None,
                                         private val _kernels: Option[Seq[String]] = None,
-                                        skipEvaluation: Option[Boolean] = None) extends Job("hls") {
+                                        runEvaluation: Option[Boolean] = None) extends Job("hls") {
   /** Returns the selected HLS tool implementation. */
   lazy val implementation: HighLevelSynthesizer.Implementation = HighLevelSynthesizer.Implementation(_implementation)
 
@@ -244,7 +245,7 @@ final case class HighLevelSynthesisJob(
   *                           core (must be > 0).
   * @param description        Description of the core (optional).
   * @param averageClockCycles Clock cycles in an average job (optional).
-  * @param skipEvaluation     Do not perform evaluation (optional).
+  * @param runEvaluation      Run an Evaluation (optional).
   * @param synthOptions       Optional parameters for synth_design.
   * @param _architectures     Name list of [[tapasco.base.Architecture]] instances.
   * @param _platforms         Name list of [[tapasco.base.Platform]] instances.
@@ -255,7 +256,7 @@ final case class ImportJob(
                             id: Kernel.Id,
                             description: Option[String] = None,
                             averageClockCycles: Option[Long] = None,
-                            skipEvaluation: Option[Boolean] = None,
+                            runEvaluation: Option[Boolean] = None,
                             synthOptions: Option[String] = None,
                             private val _architectures: Option[Seq[String]] = None,
                             private val _platforms: Option[Seq[String]] = None,

--- a/toolflow/scala/src/main/scala/tapasco/jobs/executors/HighLevelSynthesis.scala
+++ b/toolflow/scala/src/main/scala/tapasco/jobs/executors/HighLevelSynthesis.scala
@@ -77,7 +77,7 @@ protected object HighLevelSynthesis extends Executor[HighLevelSynthesisJob] {
         if (avgCC.isEmpty && k.testbenchFiles.length > 0) {
           logger.warn("executed HLS with co-sim for {}, but no co-simulation report was found", k.name)
         }
-        Some(new ImportTask(zip, t, k.id, _ => signal.release(), avgCC, job.skipEvaluation, None, 2)(cfg))
+        Some(new ImportTask(zip, t, k.id, _ => signal.release(), avgCC, job.runEvaluation, None, 2)(cfg))
       }
       case _ => None
     }

--- a/toolflow/scala/src/main/scala/tapasco/jobs/executors/Import.scala
+++ b/toolflow/scala/src/main/scala/tapasco/jobs/executors/Import.scala
@@ -56,7 +56,7 @@ object Import extends Executor[ImportJob] {
 
     val tasks = jobs map { case (j, t) =>
       val avgCC = FileAssetManager.reports.cosimReport(VLNV.fromZip(j.zipFile).name, t) map (_.latency.avg)
-      new ImportTask(j.zipFile, t, j.id, _ => signal.release(), avgCC, j.skipEvaluation, j.synthOptions, j.optimization)(cfg)
+      new ImportTask(j.zipFile, t, j.id, _ => signal.release(), avgCC, j.runEvaluation, j.synthOptions, j.optimization)(cfg)
     }
 
     tasks foreach {

--- a/toolflow/scala/src/main/scala/tapasco/parser/HighLevelSynthesisParser.scala
+++ b/toolflow/scala/src/main/scala/tapasco/parser/HighLevelSynthesisParser.scala
@@ -44,11 +44,11 @@ private object HighLevelSynthesisParser {
 
   private val jobid = identity[HighLevelSynthesisJob] _
 
-  private def skipEval: Parser[(String, Boolean)] =
-    (longOption("skipEvaluation", "SkipEval") ~ ws) map { case s => (s, true) }
+  private def evaluate: Parser[(String, Boolean)] =
+    (longOption("evaluate", "RunEvaluation") ~ ws) map { case s => (s, true) }
 
   private def options: Parser[HighLevelSynthesisJob => HighLevelSynthesisJob] =
-    (implementation | architectures | platforms | skipEval).rep map (opt =>
+    (implementation | architectures | platforms | evaluate).rep map (opt =>
       (opt map (applyOption _) fold jobid) (_ andThen _))
 
   private def applyOption(opt: (String, _)): HighLevelSynthesisJob => HighLevelSynthesisJob =
@@ -56,7 +56,7 @@ private object HighLevelSynthesisParser {
       case ("Implementation", i: String) => _.copy(_implementation = i)
       case ("Architectures", as: Seq[String@unchecked]) => _.copy(_architectures = Some(as))
       case ("Platforms", ps: Seq[String@unchecked]) => _.copy(_platforms = Some(ps))
-      case ("SkipEval", se: Boolean) => _.copy(skipEvaluation = Some(se))
+      case ("RunEvaluation", se: Boolean) => _.copy(runEvaluation = Some(se))
       case o => throw new Exception(s"parsed illegal option: $o")
     }
 }

--- a/toolflow/scala/src/main/scala/tapasco/parser/ImportParser.scala
+++ b/toolflow/scala/src/main/scala/tapasco/parser/ImportParser.scala
@@ -43,7 +43,7 @@ private object ImportParser {
   private val jobid = identity[ImportJob] _
 
   private def options: Parser[ImportJob => ImportJob] =
-    (description | avgClockCycles | skipEval | architectures | platforms | synthOptions | optimization).rep map (opts =>
+    (description | avgClockCycles | evaluate | architectures | platforms | synthOptions | optimization).rep map (opts =>
       (opts map (applyOption _) fold jobid) (_ andThen _))
 
   private def description: Parser[(String, String)] =
@@ -53,8 +53,8 @@ private object ImportParser {
     longOption("averageClockCycles", "AvgCC") ~ ws ~/
       posint.opaque("avg. number of clock cycles, integer > 0") ~ ws
 
-  private def skipEval: Parser[(String, Boolean)] =
-    (longOption("skipEvaluation", "SkipEval") ~ ws) map { case s => (s, true) }
+  private def evaluate: Parser[(String, Boolean)] =
+    (longOption("evaluate", "RunEvaluation") ~ ws) map { case s => (s, true) }
 
   private def synthOptions: Parser[(String, String)] =
     longOption("synthOptions", "SynthOptions") ~ ws ~/ qstring.opaque("additional synth_design options as string") ~ ws
@@ -65,7 +65,7 @@ private object ImportParser {
   private def applyOption(opt: (String, _)): ImportJob => ImportJob = opt match {
     case ("Description", d: String) => _.copy(description = Some(d))
     case ("AvgCC", cc: Int) => _.copy(averageClockCycles = Some(cc))
-    case ("SkipEval", se: Boolean) => _.copy(skipEvaluation = Some(se))
+    case ("RunEvaluation", se: Boolean) => _.copy(runEvaluation = Some(se))
     case ("SynthOptions", so: String) => _.copy(synthOptions = Some(so))
     case ("Architectures", as: Seq[String@unchecked]) => _.copy(_architectures = Some(as))
     case ("Platforms", ps: Seq[String@unchecked]) => _.copy(_platforms = Some(ps))

--- a/toolflow/scala/src/main/scala/tapasco/parser/Usage.scala
+++ b/toolflow/scala/src/main/scala/tapasco/parser/Usage.scala
@@ -234,8 +234,8 @@ configuration via `tapasco -n config.json`.
           "-p vc709, pynq") &
         Arg("--description TEXT", "any quoted or unquoted string containing" ~
           "additional information about the core") &
-        Arg("--skipEvaluation", "do not perform out-of-context synthesis to get" ~
-          "resource estimates, only import") &
+        Arg("--evaluate", "run out-of-context Synthesis to estimate" ~
+          "resource usage and frequency") &
         Arg("--averageClockCycles N", "any integer > 0; number of clock cycles in an" ~
           """"average" execution of the PE; used to estimate""" ~
           "the maximal throughput")))
@@ -266,7 +266,7 @@ configuration via `tapasco -n config.json`.
           "-p vc709, pynq") &
         Arg("--implementation NAME", "selects a HLS tool by name" &
           """default: "VivadoHLS"""") &
-        Arg("--skipEvaluation", "import the HLS result without performing" ~
+        Arg("--evaluate", "evaluate the HLS core using" ~
           "an out-of-context synthesis to get resource estimates")) &
       "" &
       Section("Note",

--- a/toolflow/scala/src/main/scala/tapasco/task/ImportTask.scala
+++ b/toolflow/scala/src/main/scala/tapasco/task/ImportTask.scala
@@ -43,7 +43,7 @@ import tapasco.util._
   * @param id                 Id of the kernel this core implements.
   * @param onComplete         Callback function on completion of the task.
   * @param averageClockCycles Clock cycle count in an average execution of the core (optional).
-  * @param skipEvaluation     Do not perform out-of-context synthesis for resource estimates, if true (optional).
+  * @param runEvaluation      Perform out-of-context synthesis for resource estimates, if true (optional).
   * @param cfg                TaPaSCo [[tapasco.base.Configuration]] (implicit).
   **/
 class ImportTask(val zip: Path,
@@ -51,7 +51,7 @@ class ImportTask(val zip: Path,
                  val id: Kernel.Id,
                  val onComplete: Boolean => Unit,
                  val averageClockCycles: Option[Long] = None,
-                 val skipEvaluation: Option[Boolean] = None,
+                 val runEvaluation: Option[Boolean] = None,
                  val synthOptions: Option[String] = None,
                  val optimization: Int)
                 (implicit val cfg: Configuration) extends Task with LogTracking {
@@ -70,7 +70,7 @@ class ImportTask(val zip: Path,
     val appender = LogFileTracker.setupLogFileAppender(_logFile.toString)
     logger.trace("current thread name: {}", Thread.currentThread.getName())
     logger.info(description)
-    val result = activity.Import(zip, id, t, averageClockCycles, skipEvaluation, optimization, synthOptions)
+    val result = activity.Import(zip, id, t, averageClockCycles, runEvaluation, optimization, synthOptions)
     LogFileTracker.stopLogFileAppender(appender)
     result
   }


### PR DESCRIPTION
Closes #155;

With this PR, `--skipEvaluation` is officially removed from TaPaSCo. Instead the hls and import subcommands automatically skip the Evaluation Step. If Evaluation is required by the user `--evaluate` can be used. If DSE is triggered (which requires Evaluation, the cores without Evaluation Results will automatically be evaluated).