### PR TITLE
Feature/fix xupvvh 100g

### DIFF
--- a/toolflow/vivado/platform/xupvvh-es/plugins/sfpplus.tcl
+++ b/toolflow/vivado/platform/xupvvh-es/plugins/sfpplus.tcl
@@ -1,0 +1,1 @@
+../../xupvvh/plugins/sfpplus.tcl

--- a/toolflow/vivado/platform/xupvvh-es/plugins/sfpplus_100g.tcl
+++ b/toolflow/vivado/platform/xupvvh-es/plugins/sfpplus_100g.tcl
@@ -1,0 +1,1 @@
+../../xupvvh/plugins/sfpplus_100g.tcl

--- a/toolflow/vivado/platform/xupvvh-es/plugins/sfpplus_10g.tcl
+++ b/toolflow/vivado/platform/xupvvh-es/plugins/sfpplus_10g.tcl
@@ -1,0 +1,1 @@
+../../xupvvh/plugins/sfpplus_10g.tcl

--- a/toolflow/vivado/platform/xupvvh-es/plugins/sfpplus_aurora.tcl
+++ b/toolflow/vivado/platform/xupvvh-es/plugins/sfpplus_aurora.tcl
@@ -1,0 +1,1 @@
+../../xupvvh/plugins/sfpplus_aurora.tcl

--- a/toolflow/vivado/platform/xupvvh/plugins/sfpplus_100g.tcl
+++ b/toolflow/vivado/platform/xupvvh/plugins/sfpplus_100g.tcl
@@ -129,8 +129,12 @@ namespace eval sfpplus {
 
       connect_bd_intf_net $gt_refclk [get_bd_intf_pins $core/gt_ref_clk]
       connect_bd_net [get_bd_pins $core/sys_reset] [get_bd_pins dclk_reset/peripheral_reset]
-      make_bd_intf_pins_external [get_bd_intf_pins $core/gt_rx]
-      make_bd_intf_pins_external [get_bd_intf_pins $core/gt_tx]
+      if { [::tapasco::vivado_is_newer "2020.1"] == 1} {
+        make_bd_intf_pins_external [get_bd_intf_pins $core/gt_serial_port]
+      } else {
+        make_bd_intf_pins_external [get_bd_intf_pins $core/gt_rx]
+        make_bd_intf_pins_external [get_bd_intf_pins $core/gt_tx]
+      }
       connect_bd_net [get_bd_pins $core/drp_clk] [get_bd_pins dclk_wiz/clk_out1]
       connect_bd_net [get_bd_pins $core/init_clk] [get_bd_pins dclk_wiz/clk_out1]
 


### PR DESCRIPTION
The transceiver connection of the 100G CMAC has changed in newer Vivado versions. This minimal changes fixes the issue and ensures compatiblity.