### PR TITLE
Fix memory allocator

### DIFF
--- a/runtime/libtapasco/src/allocator.rs
+++ b/runtime/libtapasco/src/allocator.rs
@@ -166,6 +166,7 @@ impl Allocator for GenericAllocator {
                     trace!("New segment is {:?}.", s);
                 }
             }
+            break;
         }
 
         if let Some(x) = element_found {


### PR DESCRIPTION
Exit loop iterating over all free memory segments as soon as first matching memory segment has been found. 