### PR TITLE
Add read to clean IRQ of HLS kernels

### DIFF
--- a/runtime/libtapasco/src/pe.rs
+++ b/runtime/libtapasco/src/pe.rs
@@ -196,7 +196,11 @@ impl PE {
         trace!("Resetting interrupts: 0x{:x} -> {}", offset, v);
         unsafe {
             let ptr = self.memory.as_ptr().offset(offset);
+
+            // mode of status register changed over time from TOW to COR
+            // so we need both read and write to 0xC
             write_volatile(ptr as *mut u32, if v { 1 } else { 0 });
+            ptr.read_volatile();
         }
         Ok(())
     }


### PR DESCRIPTION
Recently, Vitis HLS change the mode of the Interrupt Status Register from TOW to COR, which requires us to also read from that register to clear an interrupt... However, we also need to keept the write due to backwards compatibility :(