### PR TITLE
Feature/u50 support

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -498,6 +498,13 @@ tapasco_compose_AU250:
     PLATFORM: "AU250"
   extends: .tapasco_compose_no_synth
 
+tapasco_compose_AU50:
+  variables:
+    PLATFORM: "AU50"
+    VIVADO_VERSION: "2021.2"
+    XILINX_VIVADO: "/opt/cad/xilinx/vitis/Vivado/${VIVADO_VERSION}"
+  extends: .tapasco_compose_no_synth
+
 tapasco_compose_HAWK:
   variables:
     PLATFORM: "HAWK"
@@ -559,6 +566,14 @@ tapasco_compose_zedboard:
 tapasco_compose_svm_u280:
   variables:
     PLATFORM: "AU280"
+    VIVADO_VERSION: "2021.2"
+    XILINX_VIVADO: "/opt/cad/xilinx/vitis/Vivado/${VIVADO_VERSION}"
+    FLAGS: "--skipSynthesis --features SVM {enabled: true}"
+  extends: .tapasco_compose
+
+tapasco_compose_svm_u50:
+  variables:
+    PLATFORM: "AU50"
     VIVADO_VERSION: "2021.2"
     XILINX_VIVADO: "/opt/cad/xilinx/vitis/Vivado/${VIVADO_VERSION}"
     FLAGS: "--skipSynthesis --features SVM {enabled: true}"

--- a/runtime/scripts/pcie/program_pcie.tcl
+++ b/runtime/scripts/pcie/program_pcie.tcl
@@ -21,7 +21,7 @@
 
 #set default values
 set wait 1000
-set dev {xc7vx690t_0|xcvu9p_0|xcvu095_0|xcu250_0|xcvu37p_0|xcu280_0|xcu280_u55c_0|xcvc1902_1}
+set dev {xc7vx690t_0|xcvu9p_0|xcvu095_0|xcu250_0|xcvu37p_0|xcu280_0|xcu280_u55c_0|xcu50_u55n_0|xcvc1902_1}
 set probes_file {}
 set program_file {}
 set devid -1

--- a/toolflow/vivado/arch/axi4mm/axi4mm.tcl
+++ b/toolflow/vivado/arch/axi4mm/axi4mm.tcl
@@ -226,7 +226,7 @@ namespace eval arch {
     for {set i 0} {$i < [llength $mdist]} {incr i} {
       puts "  mdist[$i] = [lindex $mdist $i]"
       if {[tapasco::is_versal]} {
-        set out [tapasco::create_versal_interconnect_tree "out_$i" [lindex $mdist $i]]
+        set out [tapasco::create_smartconnect_tree "out_$i" [lindex $mdist $i]]
       } else {
         set out [tapasco::create_interconnect_tree "out_$i" [lindex $mdist $i]]
       }
@@ -255,7 +255,7 @@ namespace eval arch {
       return $out_port
     } {
       if {[tapasco::is_versal]} {
-        set in1 [tapasco::create_versal_interconnect_tree "in1" $ic_s false]
+        set in1 [tapasco::create_smartconnect_tree "in1" $ic_s false]
       } else {
         set in1 [tapasco::create_interconnect_tree "in1" $ic_s false]
       }

--- a/toolflow/vivado/common/common.tcl
+++ b/toolflow/vivado/common/common.tcl
@@ -447,8 +447,8 @@ namespace eval tapasco {
   # @param name Name of the group cell
   # @param n Number of connnections (outside)
   # @param masters if true, will create n master connections, otherwise slaves
-  proc create_versal_interconnect_tree {name n {masters true}} {
-    puts "Creating AXI Smartconnect tree for versal with name $name for $n [expr $masters ? {"masters"} : {"slaves"}]"
+  proc create_smartconnect_tree {name n {masters true}} {
+    puts "Creating AXI Smartconnect tree with name $name for $n [expr $masters ? {"masters"} : {"slaves"}]"
     puts "  tree depth: [expr int(ceil(log($n) / log(16)))]"
     puts "  instance : [current_bd_instance .]"
 

--- a/toolflow/vivado/common/data/boards/board_files/au50/1.3/LICENSE
+++ b/toolflow/vivado/common/data/boards/board_files/au50/1.3/LICENSE
@@ -1,0 +1,15 @@
+#########################################################################
+Copyright (C) 2019, Xilinx Inc - All rights reserved
+
+Licensed under the Apache License, Version 2.0 (the "License"). You may
+not use this file except in compliance with the License. A copy of the
+License is located at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+#########################################################################

--- a/toolflow/vivado/common/data/boards/board_files/au50/1.3/board.xml
+++ b/toolflow/vivado/common/data/boards/board_files/au50/1.3/board.xml
@@ -1,0 +1,1100 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Copyright (C) 2019, Xilinx Inc - All rights reserved
+ Licensed under the Apache License, Version 2.0 (the "License"). You may
+ not use this file except in compliance with the License. A copy of the
+ License is located at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations
+ under the License. -->
+<board schema_version="2.2" vendor="xilinx.com" name="au50" display_name="Alveo U50 Data Center Accelerator Card" url="http://www.xilinx.com/u50" preset_file="preset.xml" supports_ced="false">
+  <images>
+    <image name="au50_image.jpg" display_name="Alveo U50 Data Center Accelerator Card" sub_type="board" resolution="high">
+      <description>Alveo U50 Data Center Accelerator Card</description>
+    </image>
+  </images>
+  <compatible_board_revisions>
+    <revision id="0">1.3</revision>
+  </compatible_board_revisions>
+  <file_version>1.3</file_version>
+  <description>Alveo U50 Data Center Accelerator Card </description>
+  <parameters>
+    <parameter name="heat_sink_type" value="medium" value_type="string"/>
+    <parameter name="heat_sink_temperature" value_type="range" value_min="20.0" value_max="30.0"/>
+  </parameters>
+  <jumpers>
+  </jumpers>
+  <data_properties>
+    <data_property_group name="OPERATING_CONDITIONS">
+      <data_property_group name="SUPPLY_CURRENT_BUDGET">
+        <data_property name="VCCINT" value="42"/>
+        <data_property name="VCCINT_IO" value="7.38"/>
+        <data_property name="VCCBRAM" value="1.62"/>
+        <data_property name="VCCAUX" value="1.19"/>
+        <data_property name="VCCAUX_IO" value="0.056"/>
+        <data_property name="VCCO18" value="0.014"/>
+        <data_property name="VCC_IO_HBM" value="3.84"/>
+        <data_property name="VCC_HBM" value="4.16"/>
+        <data_property name="VCCAUX_HBM" value="0.2"/>
+        <data_property name="MGTYVCCAUX" value="0.144"/>
+        <data_property name="MGTYAVCC" value="1.4"/>
+        <data_property name="MGTYAVTT" value="3.6"/>
+        <data_property name="VCCADC" value="0.02"/>
+      </data_property_group>
+      <data_property name="THETAJA" value="0.75"/>
+      <data_property name="AMBIENT_TEMP" value="55"/>
+      <data_property name="DESIGN_POWER_BUDGET" value="60"/>
+    </data_property_group>
+  </data_properties>
+  <components>
+    <component name="part0" display_name="XCU50 FPGA" type="fpga" part_name="xcu50-fsvh2104-2-e" pin_map_file="part0_pins.xml" vendor="xilinx" spec_url="http://www.xilinx.com/u50">
+      <description>XCU50 FPGA</description>
+      <interfaces>
+        <interface mode="slave" name="pcie_perstn" type="xilinx.com:signal:reset_rtl:1.0" of_component="pci_express">
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xdma" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="qdma" order="1"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="RST" physical_port="pcie_perstn" dir="inout">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="PCIE_PERSTN"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+          <parameters>
+            <parameter name="rst_polarity" value="0"/>
+            <parameter name="type" value="PCIE_PERST"/>
+          </parameters>
+        </interface>
+        <interface mode="master" name="hbm_cattrip" type="xilinx.com:interface:gpio_rtl:1.0" of_component="hbm_cattrip">
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="hbm" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="axi_gpio" order="1"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="TRI_O" physical_port="hbm_cattrip" dir="out">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="HBM_CATTRIP"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+        </interface>
+        <interface mode="master" name="qsfp28_leds" type="xilinx.com:interface:gpio_rtl:1.0" of_component="qsfp28_leds">
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="axi_gpio" order="0"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="TRI_O" physical_port="leds_6bits_tri_o" dir="out" left="5" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_ACTIVITY_LED"/>
+                <pin_map port_index="1" component_pin="QSFP28_0_STATUS_LEDG"/>
+                <pin_map port_index="2" component_pin="QSFP28_0_STATUS_LEDY"/>
+                <pin_map port_index="3" component_pin="QSFP28_1_ACTIVITY_LED"/>
+                <pin_map port_index="4" component_pin="QSFP28_1_STATUS_LEDG"/>
+                <pin_map port_index="5" component_pin="QSFP28_1_STATUS_LEDY"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+        </interface>
+        <interface mode="master" name="uart_msp" type="xilinx.com:interface:uart_rtl:1.0" of_component="uart_msp">
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="axi_uart16550" order="0"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="TxD" physical_port="uart_msp_txd" dir="out">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="FPGA_TXD_MSP"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="RxD" physical_port="uart_msp_rxd" dir="in">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="FPGA_RXD_MSP"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+        </interface>
+        <interface mode="master" name="reset_gpio2_si5394" type="xilinx.com:interface:gpio_rtl:1.0" of_component="reset_si5394" preset_proc="reset2_si5394_preset">
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="axi_gpio" order="0"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="TRI_O" physical_port="SI_RSTBB" dir="out">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="SI_RSTBB"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+        </interface>
+        <interface mode="master" name="gpio_si5394" type="xilinx.com:interface:gpio_rtl:1.0" of_component="gpio_si5394">
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="axi_gpio" order="0"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="TRI_I" physical_port="SI_INTRB_PLL_LOCK_IN_LOS" dir="in" left="2" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="SI_INTRB"/>
+                <pin_map port_index="1" component_pin="SI_PLL_LOCK"/>
+                <pin_map port_index="2" component_pin="SI_IN_LOS"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+        </interface>
+        <interface mode="master" name="msp_gpio" type="xilinx.com:interface:gpio_rtl:1.0" of_component="msp_gpio">
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="axi_gpio" order="0"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="TRI_I" physical_port="GPIO_MSP_i" dir="in" left="1" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="GPIO_MSP0"/>
+                <pin_map port_index="1" component_pin="GPIO_MSP1"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+        </interface>
+        <interface mode="master" name="iic_si5394" type="xilinx.com:interface:iic_rtl:1.0" of_component="iic_si5394">
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="axi_iic" order="0"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="SDA_I" physical_port="iic_si5394_sda_i" dir="inout">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="I2C_SI5394_SDA"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="SDA_O" physical_port="iic_si5394_sda_o" dir="inout">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="I2C_SI5394_SDA"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="SDA_T" physical_port="iic_si5394_sda_t" dir="inout">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="I2C_SI5394_SDA"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="SCL_I" physical_port="iic_si5394_scl_i" dir="inout">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="I2C_SI5394_SCLK"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="SCL_O" physical_port="iic_si5394_scl_o" dir="inout">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="I2C_SI5394_SCLK"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="SCL_T" physical_port="iic_si5394_scl_t" dir="inout">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="I2C_SI5394_SCLK"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+        </interface>
+        <interface mode="slave" name="qsfp_161mhz" type="xilinx.com:interface:diff_clock_rtl:1.0" of_component="qsfp">
+          <parameters>
+            <parameter name="frequency" value="161132812"/>
+          </parameters>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="usxgmii" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="l_ethernet" order="2"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="cmac_usplus" order="3"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="CLK_P" physical_port="qsfp_161mhz_clk_p" dir="in">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="SYNCE_CLK_P"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="CLK_N" physical_port="qsfp_161mhz_clk_n" dir="in">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="SYNCE_CLK_N"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+        </interface>
+        <interface mode="slave" name="qsfp_322mhz" type="xilinx.com:interface:diff_clock_rtl:1.0" of_component="qsfp">
+          <parameters>
+            <parameter name="frequency" value="322265625"/>
+          </parameters>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="usxgmii" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="l_ethernet" order="2"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="cmac_usplus" order="3"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="CLK_P" physical_port="qsfp_322mhz_clk_p" dir="in">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="CLK_1588_P"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="CLK_N" physical_port="qsfp_322mhz_clk_n" dir="in">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="CLK_1588_N"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+        </interface>
+        <interface mode="slave" name="cmc_clk" type="xilinx.com:interface:diff_clock_rtl:1.0" of_component="cmc_clk">
+          <parameters>
+            <parameter name="frequency" value="100000000"/>
+          </parameters>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="clk_wiz" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="util_ds_buf" order="1"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="CLK_P" physical_port="cmc_clk_clk_p" dir="in">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="SYSCLK2_P"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="CLK_N" physical_port="cmc_clk_clk_n" dir="in">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="SYSCLK2_N"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+        </interface>
+        <interface mode="slave" name="hbm_clk" type="xilinx.com:interface:diff_clock_rtl:1.0" of_component="hbm_clk">
+          <parameters>
+            <parameter name="frequency" value="100000000"/>
+          </parameters>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="util_ds_buf" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="clk_wiz" order="1"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="CLK_P" physical_port="hbm_clk_clk_p" dir="in">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="SYSCLK3_P"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="CLK_N" physical_port="hbm_clk_clk_n" dir="in">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="SYSCLK3_N"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+        </interface>
+        <interface mode="slave" name="pcie_refclk" type="xilinx.com:interface:diff_clock_rtl:1.0" of_component="pcie_refclk" preset_proc="pcie_refclk_preset">
+          <parameters>
+            <parameter name="frequency" value="100000000"/>
+          </parameters>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="util_ds_buf" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="clk_wiz" order="1"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="CLK_P" physical_port="pcie_refclk_clk_p" dir="in">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="PCIE_REFCLK1_P"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="CLK_N" physical_port="pcie_refclk_clk_n" dir="in">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="PCIE_REFCLK1_N"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+        </interface>
+        <interface mode="master" name="pci_express_x1" type="xilinx.com:interface:pcie_7x_mgt_rtl:1.0" of_component="pci_express" preset_proc="pciex1_preset">
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xdma" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="qdma" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="pcie4c_uscale_plus" order="2"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="txn" physical_port="pcie_tx0_n" dir="out">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_tx0_n"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="rxn" physical_port="pcie_rx0_n" dir="in">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_rx0_n"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="txp" physical_port="pcie_tx0_p" dir="out">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_tx0_p"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="rxp" physical_port="pcie_rx0_p" dir="in">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_rx0_p"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+          <parameters>
+            <parameter name="block_location" value="PCIE4C_X1Y0"/>
+          </parameters>
+        </interface>
+        <interface mode="master" name="pci_express_x2" type="xilinx.com:interface:pcie_7x_mgt_rtl:1.0" of_component="pci_express" preset_proc="pciex2_preset">
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xdma" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="qdma" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="pcie4c_uscale_plus" order="2"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="txn" physical_port="pcie_tx0_nx2" dir="out" left="1" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_tx0_n"/>
+                <pin_map port_index="1" component_pin="pcie_tx1_n"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="rxn" physical_port="pcie_rx0_nx2" dir="in" left="1" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_rx0_n"/>
+                <pin_map port_index="1" component_pin="pcie_rx1_n"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="txp" physical_port="pcie_tx0_px2" dir="out" left="1" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_tx0_p"/>
+                <pin_map port_index="1" component_pin="pcie_tx1_p"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="rxp" physical_port="pcie_rx0_px2" dir="in" left="1" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_rx0_p"/>
+                <pin_map port_index="1" component_pin="pcie_rx1_p"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+          <parameters>
+            <parameter name="block_location" value="PCIE4C_X1Y0"/>
+          </parameters>
+        </interface>
+        <interface mode="master" name="pci_express_x4" type="xilinx.com:interface:pcie_7x_mgt_rtl:1.0" of_component="pci_express" preset_proc="pciex4_preset">
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xdma" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="qdma" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="pcie4c_uscale_plus" order="2"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="txn" physical_port="pcie_tx0_nx4" dir="out" left="3" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_tx0_n"/>
+                <pin_map port_index="1" component_pin="pcie_tx1_n"/>
+                <pin_map port_index="2" component_pin="pcie_tx2_n"/>
+                <pin_map port_index="3" component_pin="pcie_tx3_n"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="rxn" physical_port="pcie_rx0_nx4" dir="in" left="3" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_rx0_n"/>
+                <pin_map port_index="1" component_pin="pcie_rx1_n"/>
+                <pin_map port_index="2" component_pin="pcie_rx2_n"/>
+                <pin_map port_index="3" component_pin="pcie_rx3_n"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="txp" physical_port="pcie_tx0_px4" dir="out" left="3" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_tx0_p"/>
+                <pin_map port_index="1" component_pin="pcie_tx1_p"/>
+                <pin_map port_index="2" component_pin="pcie_tx2_p"/>
+                <pin_map port_index="3" component_pin="pcie_tx3_p"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="rxp" physical_port="pcie_rx0_px4" dir="in" left="3" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_rx0_p"/>
+                <pin_map port_index="1" component_pin="pcie_rx1_p"/>
+                <pin_map port_index="2" component_pin="pcie_rx2_p"/>
+                <pin_map port_index="3" component_pin="pcie_rx3_p"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+          <parameters>
+            <parameter name="block_location" value="PCIE4C_X1Y0"/>
+          </parameters>
+        </interface>
+        <interface mode="master" name="pci_express_x8" type="xilinx.com:interface:pcie_7x_mgt_rtl:1.0" of_component="pci_express" preset_proc="pciex8_preset">
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xdma" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="qdma" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="pcie4c_uscale_plus" order="2"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="txn" physical_port="pcie_tx0_nx8" dir="out" left="7" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_tx0_n"/>
+                <pin_map port_index="1" component_pin="pcie_tx1_n"/>
+                <pin_map port_index="2" component_pin="pcie_tx2_n"/>
+                <pin_map port_index="3" component_pin="pcie_tx3_n"/>
+                <pin_map port_index="4" component_pin="pcie_tx4_n"/>
+                <pin_map port_index="5" component_pin="pcie_tx5_n"/>
+                <pin_map port_index="6" component_pin="pcie_tx6_n"/>
+                <pin_map port_index="7" component_pin="pcie_tx7_n"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="rxn" physical_port="pcie_rx0_nx8" dir="in" left="7" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_rx0_n"/>
+                <pin_map port_index="1" component_pin="pcie_rx1_n"/>
+                <pin_map port_index="2" component_pin="pcie_rx2_n"/>
+                <pin_map port_index="3" component_pin="pcie_rx3_n"/>
+                <pin_map port_index="4" component_pin="pcie_rx4_n"/>
+                <pin_map port_index="5" component_pin="pcie_rx5_n"/>
+                <pin_map port_index="6" component_pin="pcie_rx6_n"/>
+                <pin_map port_index="7" component_pin="pcie_rx7_n"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="txp" physical_port="pcie_tx0_px8" dir="out" left="7" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_tx0_p"/>
+                <pin_map port_index="1" component_pin="pcie_tx1_p"/>
+                <pin_map port_index="2" component_pin="pcie_tx2_p"/>
+                <pin_map port_index="3" component_pin="pcie_tx3_p"/>
+                <pin_map port_index="4" component_pin="pcie_tx4_p"/>
+                <pin_map port_index="5" component_pin="pcie_tx5_p"/>
+                <pin_map port_index="6" component_pin="pcie_tx6_p"/>
+                <pin_map port_index="7" component_pin="pcie_tx7_p"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="rxp" physical_port="pcie_rx0_px8" dir="in" left="7" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_rx0_p"/>
+                <pin_map port_index="1" component_pin="pcie_rx1_p"/>
+                <pin_map port_index="2" component_pin="pcie_rx2_p"/>
+                <pin_map port_index="3" component_pin="pcie_rx3_p"/>
+                <pin_map port_index="4" component_pin="pcie_rx4_p"/>
+                <pin_map port_index="5" component_pin="pcie_rx5_p"/>
+                <pin_map port_index="6" component_pin="pcie_rx6_p"/>
+                <pin_map port_index="7" component_pin="pcie_rx7_p"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+          <parameters>
+            <parameter name="block_location" value="PCIE4C_X1Y0"/>
+          </parameters>
+        </interface>
+        <interface mode="master" name="pci_express_x16" type="xilinx.com:interface:pcie_7x_mgt_rtl:1.0" of_component="pci_express" preset_proc="pciex16_preset">
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xdma" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="qdma" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="pcie4c_uscale_plus" order="2"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="txn" physical_port="pcie_tx0_nx16" dir="out" left="15" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_tx0_n"/>
+                <pin_map port_index="1" component_pin="pcie_tx1_n"/>
+                <pin_map port_index="2" component_pin="pcie_tx2_n"/>
+                <pin_map port_index="3" component_pin="pcie_tx3_n"/>
+                <pin_map port_index="4" component_pin="pcie_tx4_n"/>
+                <pin_map port_index="5" component_pin="pcie_tx5_n"/>
+                <pin_map port_index="6" component_pin="pcie_tx6_n"/>
+                <pin_map port_index="7" component_pin="pcie_tx7_n"/>
+                <pin_map port_index="8" component_pin="pcie_tx8_n"/>
+                <pin_map port_index="9" component_pin="pcie_tx9_n"/>
+                <pin_map port_index="10" component_pin="pcie_tx10_n"/>
+                <pin_map port_index="11" component_pin="pcie_tx11_n"/>
+                <pin_map port_index="12" component_pin="pcie_tx12_n"/>
+                <pin_map port_index="13" component_pin="pcie_tx13_n"/>
+                <pin_map port_index="14" component_pin="pcie_tx14_n"/>
+                <pin_map port_index="15" component_pin="pcie_tx15_n"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="rxn" physical_port="pcie_rx0_nx16" dir="in" left="15" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_rx0_n"/>
+                <pin_map port_index="1" component_pin="pcie_rx1_n"/>
+                <pin_map port_index="2" component_pin="pcie_rx2_n"/>
+                <pin_map port_index="3" component_pin="pcie_rx3_n"/>
+                <pin_map port_index="4" component_pin="pcie_rx4_n"/>
+                <pin_map port_index="5" component_pin="pcie_rx5_n"/>
+                <pin_map port_index="6" component_pin="pcie_rx6_n"/>
+                <pin_map port_index="7" component_pin="pcie_rx7_n"/>
+                <pin_map port_index="8" component_pin="pcie_rx8_n"/>
+                <pin_map port_index="9" component_pin="pcie_rx9_n"/>
+                <pin_map port_index="10" component_pin="pcie_rx10_n"/>
+                <pin_map port_index="11" component_pin="pcie_rx11_n"/>
+                <pin_map port_index="12" component_pin="pcie_rx12_n"/>
+                <pin_map port_index="13" component_pin="pcie_rx13_n"/>
+                <pin_map port_index="14" component_pin="pcie_rx14_n"/>
+                <pin_map port_index="15" component_pin="pcie_rx15_n"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="txp" physical_port="pcie_tx0_px16" dir="out" left="15" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_tx0_p"/>
+                <pin_map port_index="1" component_pin="pcie_tx1_p"/>
+                <pin_map port_index="2" component_pin="pcie_tx2_p"/>
+                <pin_map port_index="3" component_pin="pcie_tx3_p"/>
+                <pin_map port_index="4" component_pin="pcie_tx4_p"/>
+                <pin_map port_index="5" component_pin="pcie_tx5_p"/>
+                <pin_map port_index="6" component_pin="pcie_tx6_p"/>
+                <pin_map port_index="7" component_pin="pcie_tx7_p"/>
+                <pin_map port_index="8" component_pin="pcie_tx8_p"/>
+                <pin_map port_index="9" component_pin="pcie_tx9_p"/>
+                <pin_map port_index="10" component_pin="pcie_tx10_p"/>
+                <pin_map port_index="11" component_pin="pcie_tx11_p"/>
+                <pin_map port_index="12" component_pin="pcie_tx12_p"/>
+                <pin_map port_index="13" component_pin="pcie_tx13_p"/>
+                <pin_map port_index="14" component_pin="pcie_tx14_p"/>
+                <pin_map port_index="15" component_pin="pcie_tx15_p"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="rxp" physical_port="pcie_rx0_px16" dir="in" left="15" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="pcie_rx0_p"/>
+                <pin_map port_index="1" component_pin="pcie_rx1_p"/>
+                <pin_map port_index="2" component_pin="pcie_rx2_p"/>
+                <pin_map port_index="3" component_pin="pcie_rx3_p"/>
+                <pin_map port_index="4" component_pin="pcie_rx4_p"/>
+                <pin_map port_index="5" component_pin="pcie_rx5_p"/>
+                <pin_map port_index="6" component_pin="pcie_rx6_p"/>
+                <pin_map port_index="7" component_pin="pcie_rx7_p"/>
+                <pin_map port_index="8" component_pin="pcie_rx8_p"/>
+                <pin_map port_index="9" component_pin="pcie_rx9_p"/>
+                <pin_map port_index="10" component_pin="pcie_rx10_p"/>
+                <pin_map port_index="11" component_pin="pcie_rx11_p"/>
+                <pin_map port_index="12" component_pin="pcie_rx12_p"/>
+                <pin_map port_index="13" component_pin="pcie_rx13_p"/>
+                <pin_map port_index="14" component_pin="pcie_rx14_p"/>
+                <pin_map port_index="15" component_pin="pcie_rx15_p"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+          <parameters>
+            <parameter name="block_location" value="PCIE4C_X1Y0"/>
+          </parameters>
+        </interface>
+        <interface mode="master" name="qsfp_1x" type="xilinx.com:interface:gt_rtl:1.0" of_component="qsfp" preset_proc="qsfp0_1x_preset">
+          <description>1-lane GT interface over QSFP</description>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="usxgmii" order="1"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="GTX_N" physical_port="QSFP28_0_txn1" dir="out">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_TX_N0"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="GTX_P" physical_port="QSFP28_0_txp1" dir="out">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_TX_P0"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="GRX_N" physical_port="QSFP28_0_rxn1" dir="in">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_RX_N0"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="GRX_P" physical_port="QSFP28_0_rxp1" dir="in">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_RX_P0"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+          <parameters>
+            <parameter name="gt_loc" value=""/>
+          </parameters>
+        </interface>
+        <interface mode="master" name="qsfp_2x" type="xilinx.com:interface:gt_rtl:1.0" of_component="qsfp" preset_proc="qsfp0_2x_preset">
+          <description>2-lane GT interface over QSFP</description>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="usxgmii" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="l_ethernet" order="2"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="GTX_N" physical_port="QSFP28_0_txn2" dir="out" left="1" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_TX_N0"/>
+                <pin_map port_index="1" component_pin="QSFP28_0_TX_N1"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="GTX_P" physical_port="QSFP28_0_txp2" dir="out" left="1" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_TX_P0"/>
+                <pin_map port_index="1" component_pin="QSFP28_0_TX_P1"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="GRX_N" physical_port="QSFP28_0_rxn2" dir="in" left="1" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_RX_N0"/>
+                <pin_map port_index="1" component_pin="QSFP28_0_RX_N1"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="GRX_P" physical_port="QSFP28_0_rxp2" dir="in" left="1" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_RX_P0"/>
+                <pin_map port_index="1" component_pin="QSFP28_0_RX_P1"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+          <parameters>
+            <parameter name="gt_loc" value=""/>
+          </parameters>
+        </interface>
+        <interface mode="master" name="qsfp_3x" type="xilinx.com:interface:gt_rtl:1.0" of_component="qsfp" preset_proc="qsfp0_3x_preset">
+          <description>3-lane GT interface over QSFP</description>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="usxgmii" order="1"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="GTX_N" physical_port="QSFP28_0_txn3" dir="out" left="2" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_TX_N0"/>
+                <pin_map port_index="1" component_pin="QSFP28_0_TX_N1"/>
+                <pin_map port_index="2" component_pin="QSFP28_0_TX_N2"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="GTX_P" physical_port="QSFP28_0_txp3" dir="out" left="2" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_TX_P0"/>
+                <pin_map port_index="1" component_pin="QSFP28_0_TX_P1"/>
+                <pin_map port_index="2" component_pin="QSFP28_0_TX_P2"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="GRX_N" physical_port="QSFP28_0_rxn3" dir="in" left="2" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_RX_N0"/>
+                <pin_map port_index="1" component_pin="QSFP28_0_RX_N1"/>
+                <pin_map port_index="2" component_pin="QSFP28_0_RX_N2"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="GRX_P" physical_port="QSFP28_0_rxp3" dir="in" left="2" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_RX_P0"/>
+                <pin_map port_index="1" component_pin="QSFP28_0_RX_P1"/>
+                <pin_map port_index="2" component_pin="QSFP28_0_RX_P2"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+          <parameters>
+            <parameter name="gt_loc" value=""/>
+          </parameters>
+        </interface>
+        <interface mode="master" name="qsfp_4x" type="xilinx.com:interface:gt_rtl:1.0" of_component="qsfp" preset_proc="qsfp0_4x_preset">
+          <description>4-lane GT interface over QSFP</description>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="usxgmii" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="l_ethernet" order="2"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="cmac_usplus" order="3"/>
+          </preferred_ips>
+          <port_maps>
+            <port_map logical_port="GTX_N" physical_port="QSFP28_0_txn4" dir="out" left="3" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_TX_N0"/>
+                <pin_map port_index="1" component_pin="QSFP28_0_TX_N1"/>
+                <pin_map port_index="2" component_pin="QSFP28_0_TX_N2"/>
+                <pin_map port_index="3" component_pin="QSFP28_0_TX_N3"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="GTX_P" physical_port="QSFP28_0_txp4" dir="out" left="3" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_TX_P0"/>
+                <pin_map port_index="1" component_pin="QSFP28_0_TX_P1"/>
+                <pin_map port_index="2" component_pin="QSFP28_0_TX_P2"/>
+                <pin_map port_index="3" component_pin="QSFP28_0_TX_P3"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="GRX_N" physical_port="QSFP28_0_rxn4" dir="in" left="3" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_RX_N0"/>
+                <pin_map port_index="1" component_pin="QSFP28_0_RX_N1"/>
+                <pin_map port_index="2" component_pin="QSFP28_0_RX_N2"/>
+                <pin_map port_index="3" component_pin="QSFP28_0_RX_N3"/>
+              </pin_maps>
+            </port_map>
+            <port_map logical_port="GRX_P" physical_port="QSFP28_0_rxp4" dir="in" left="3" right="0">
+              <pin_maps>
+                <pin_map port_index="0" component_pin="QSFP28_0_RX_P0"/>
+                <pin_map port_index="1" component_pin="QSFP28_0_RX_P1"/>
+                <pin_map port_index="2" component_pin="QSFP28_0_RX_P2"/>
+                <pin_map port_index="3" component_pin="QSFP28_0_RX_P3"/>
+              </pin_maps>
+            </port_map>
+          </port_maps>
+          <parameters>
+            <parameter name="gt_loc" value=""/>
+          </parameters>
+        </interface>
+      </interfaces>
+    </component>
+    <component name="hbm_cattrip" display_name="HBM CATTRIP (Mandatory)" type="chip" sub_type="led" major_group="General Purpose Input or Output">
+      <description>HBM CATTRIP Active High to gate power supply via Satellite Controller. Please ensure proper connection to PIN J18 and tie low if not connected to the HBM.</description>
+      <preferred_ips>
+        <preferred_ip vendor="xilinx.com" library="ip" name="hbm" order="0"/>
+      </preferred_ips>
+    </component>
+    <component name="qsfp28_leds" display_name="QSFP28 LEDs" type="chip" sub_type="led" major_group="General Purpose Input or Output" part_name="SML-LX0603IW-TR" vendor="LUMEX">
+      <description>Status LEDs, 5-3 are for QSFP1 and 2-0 are for QSFP0 in the order [STATUS_LEDY,STATUS_LEDG,ACTIVITY_LED] </description>
+    </component>
+    <component name="uart_msp" display_name="UART MSP" type="chip" sub_type="uart" major_group="Miscellaneous">
+      <description>UART interface to MSP432 Satellite Controller from CMS</description>
+      <pins>
+        <pin index="0" name="uart_msp_TXD" iostandard="LVCMOS18"/>
+        <pin index="1" name="uart_msp_RXD" iostandard="LVCMOS18"/>
+      </pins>
+      <preferred_ips>
+        <preferred_ip vendor="xilinx.com" library="ip" name="cms_subsystem" order="0"/>
+      </preferred_ips>
+    </component>
+    <component name="reset_si5394" display_name="Reset to SI5394" type="chip" sub_type="led" major_group="General Purpose Input or Output" part_name="SI5394" vendor="Silicon Labs" spec_url="www.silabs.com">
+      <description>GPIO reset to SI5394 (SI_RSTBB) </description>
+    </component>
+    <component name="gpio_si5394" display_name="GPIO from SI5394" type="chip" sub_type="led" major_group="General Purpose Input or Output" part_name="SI5394" vendor="Silicon Labs" spec_url="www.silabs.com">
+      <description>GPIO from SI5394 (SI_INTRB, SI_PLL_LOCK, SI_IN_LOS)</description>
+    </component>
+    <component name="msp_gpio" display_name="GPIO from MSP" type="chip" sub_type="led" major_group="General Purpose Input or Output">
+      <description>GPIO signals from MSP Satellite Controller to the CMS</description>
+      <preferred_ips>
+        <preferred_ip vendor="xilinx.com" library="ip" name="cms_subsystem" order="0"/>
+      </preferred_ips>
+    </component>
+    <component name="iic_si5394" display_name="I2C SI5394" type="chip" sub_type="mux" major_group="Miscellaneous" part_name="SI5394" vendor="Silicon Labs" spec_url="www.silabs.com">
+      <description>I2C to SI5394</description>
+    </component>
+    <component name="qsfp_161mhz" display_name="QSFP Differential Clock 0" type="chip" sub_type="system_clock" major_group="High Speed Tranceivers" part_name="SI5394" vendor="Silicon Labs" spec_url="www.silabs.com">
+      <description>1.2V LVDS differential 161 MHz oscillator used as a GT reference clock on the board labelled SYNCE_CLK.</description>
+      <parameters>
+        <parameter name="frequency" value="161132812"/>
+      </parameters>
+      <preferred_ips>
+        <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+      </preferred_ips>
+    </component>
+    <component name="qsfp_322mhz" display_name="QSFP Differential Clock 1" type="chip" sub_type="system_clock" major_group="High Speed Tranceivers" part_name="SI5394" vendor="Silicon Labs" spec_url="www.silabs.com">
+      <description>1.2V LVDS differential 322 MHz oscillator used as a GT reference clock on the board labelled 1588_CLK.</description>
+      <parameters>
+        <parameter name="frequency" value="322265625"/>
+      </parameters>
+      <preferred_ips>
+        <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+      </preferred_ips>
+    </component>
+    <component name="cmc_clk" display_name="CMC Differential Clock" type="chip" sub_type="system_clock" major_group="Clock Sources" part_name="SI53306-B-GM" vendor="Silicon Labs" spec_url="www.silabs.com">
+      <description>1.2V LVDS differential 100 MHz oscillator used as CMC differential clock input on the board</description>
+      <parameters>
+        <parameter name="frequency" value="100000000"/>
+      </parameters>
+      <preferred_ips>
+        <preferred_ip vendor="xilinx.com" library="ip" name="clk_wiz" order="0"/>
+        <preferred_ip vendor="xilinx.com" library="ip" name="util_ds_buf" order="1"/>
+      </preferred_ips>
+    </component>
+    <component name="hbm_clk" display_name="HBM Differential Clock" type="chip" sub_type="system_clock" major_group="Clock Sources" part_name="SI53306-B-GM" vendor="Silicon Labs" spec_url="www.silabs.com">
+      <description>1.2V LVDS differential 100 MHz oscillator used as HBM differential clock input on the board</description>
+      <parameters>
+        <parameter name="frequency" value="100000000"/>
+      </parameters>
+      <preferred_ips>
+        <preferred_ip vendor="xilinx.com" library="ip" name="util_ds_buf" order="0"/>
+        <preferred_ip vendor="xilinx.com" library="ip" name="clk_wiz" order="1"/>
+      </preferred_ips>
+    </component>
+    <component name="pcie_refclk" display_name="PCIe Reference Clock" type="chip" sub_type="mgt_clock" major_group="Clock Sources" part_name="pcie_8lane_edge" vendor="Clock" spec_url="">
+      <description>Clock input from PCI Express edge connector</description>
+      <parameters>
+        <parameter name="frequency" value="100000000"/>
+      </parameters>
+      <preferred_ips>
+        <preferred_ip vendor="xilinx.com" library="ip" name="util_ds_buf" order="0"/>
+        <preferred_ip vendor="xilinx.com" library="ip" name="clk_wiz" order="1"/>
+      </preferred_ips>
+    </component>
+    <component name="pci_express" display_name="PCI Express" type="chip" sub_type="chip" major_group="High Speed Tranceivers">
+      <description>PCI Express</description>
+      <component_modes>
+        <component_mode name="pci_express_x1" display_name="pci_express x1 ">
+          <interfaces>
+            <interface name="pci_express_x1"/>
+            <interface name="pcie_perstn" optional="true"/>
+          </interfaces>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xdma" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="qdma" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="pcie4c_uscale_plus" order="2"/>
+          </preferred_ips>
+        </component_mode>
+        <component_mode name="pci_express_x2" display_name="pci_express x2 ">
+          <interfaces>
+            <interface name="pci_express_x2"/>
+            <interface name="pcie_perstn" optional="true"/>
+          </interfaces>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xdma" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="qdma" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="pcie4c_uscale_plus" order="2"/>
+          </preferred_ips>
+        </component_mode>
+        <component_mode name="pci_express_x4" display_name="pci_express x4 ">
+          <interfaces>
+            <interface name="pci_express_x4"/>
+            <interface name="pcie_perstn" optional="true"/>
+          </interfaces>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xdma" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="qdma" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="pcie4c_uscale_plus" order="2"/>
+          </preferred_ips>
+        </component_mode>
+        <component_mode name="pci_express_x8" display_name="pci_express x8 ">
+          <interfaces>
+            <interface name="pci_express_x8"/>
+            <interface name="pcie_perstn" optional="true"/>
+          </interfaces>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xdma" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="qdma" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="pcie4c_uscale_plus" order="2"/>
+          </preferred_ips>
+        </component_mode>
+        <component_mode name="pci_express_x16" display_name="pci_express x16 ">
+          <interfaces>
+            <interface name="pci_express_x16"/>
+            <interface name="pcie_perstn" optional="true"/>
+          </interfaces>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xdma" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="qdma" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="pcie4c_uscale_plus" order="2"/>
+          </preferred_ips>
+        </component_mode>
+      </component_modes>
+    </component>
+    <component name="qsfp" display_name="QSFP Connector" type="chip" sub_type="sfp" major_group="High Speed Tranceivers" part_name="M88E1111_BAB1C000" vendor="Marvell" spec_url="www.marvell.com">
+      <description>QSFP Connector 0</description>
+      <component_modes>
+        <component_mode name="qsfp_1x_161" display_name="qsfp_1x_161">
+          <interfaces>
+            <interface name="qsfp_1x"/>
+            <interface name="qsfp_161mhz" optional="true"/>
+          </interfaces>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="usxgmii" order="1"/>
+          </preferred_ips>
+        </component_mode>
+        <component_mode name="qsfp_2x_161" display_name="qsfp_2x_161">
+          <interfaces>
+            <interface name="qsfp_2x"/>
+            <interface name="qsfp_161mhz" optional="true"/>
+          </interfaces>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="usxgmii" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="l_ethernet" order="1"/>
+          </preferred_ips>
+        </component_mode>
+        <component_mode name="qsfp_3x_161" display_name="qsfp_3x_161">
+          <interfaces>
+            <interface name="qsfp_3x"/>
+            <interface name="qsfp_161mhz" optional="true"/>
+          </interfaces>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="usxgmii" order="1"/>
+          </preferred_ips>
+        </component_mode>
+        <component_mode name="qsfp_4x_161" display_name="qsfp_4x_161">
+          <interfaces>
+            <interface name="qsfp_4x"/>
+            <interface name="qsfp_161mhz" optional="true"/>
+          </interfaces>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="usxgmii" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="l_ethernet" order="2"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="cmac_usplus" order="3"/>
+          </preferred_ips>
+        </component_mode>
+        <component_mode name="qsfp_1x_322" display_name="qsfp_1x_322">
+          <interfaces>
+            <interface name="qsfp_1x"/>
+            <interface name="qsfp_322mhz" optional="true"/>
+          </interfaces>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="usxgmii" order="1"/>
+          </preferred_ips>
+        </component_mode>
+        <component_mode name="qsfp_2x_322" display_name="qsfp_2x_322">
+          <interfaces>
+            <interface name="qsfp_2x"/>
+            <interface name="qsfp_322mhz" optional="true"/>
+          </interfaces>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="usxgmii" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="l_ethernet" order="1"/>
+          </preferred_ips>
+        </component_mode>
+        <component_mode name="qsfp_3x_322" display_name="qsfp_3x_322">
+          <interfaces>
+            <interface name="qsfp_3x"/>
+            <interface name="qsfp_322mhz" optional="true"/>
+          </interfaces>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="usxgmii" order="1"/>
+          </preferred_ips>
+        </component_mode>
+        <component_mode name="qsfp_4x_322" display_name="qsfp_4x_322">
+          <interfaces>
+            <interface name="qsfp_4x"/>
+            <interface name="qsfp_322mhz" optional="true"/>
+          </interfaces>
+          <preferred_ips>
+            <preferred_ip vendor="xilinx.com" library="ip" name="xxv_ethernet" order="0"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="usxgmii" order="1"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="l_ethernet" order="2"/>
+            <preferred_ip vendor="xilinx.com" library="ip" name="cmac_usplus" order="3"/>
+          </preferred_ips>
+        </component_mode>
+      </component_modes>
+    </component>
+  </components>
+  <jtag_chains>
+    <jtag_chain name="chain1">
+      <position name="0" component="part0"/>
+    </jtag_chain>
+  </jtag_chains>
+  <connections>
+    <connection name="part0_pcie_perstn" component1="part0" component2="pcie_perstn">
+      <connection_map name="part0_pcie_perstn" c1_st_index="0" c1_end_index="0" c2_st_index="0" c2_end_index="0"/>
+    </connection>
+    <connection name="part0_hbm_cattrip" component1="part0" component2="hbm_cattrip">
+      <connection_map name="part0_hbm_cattrip" typical_delay="5" c1_st_index="2" c1_end_index="2" c2_st_index="0" c2_end_index="0"/>
+    </connection>
+    <connection name="part0_qsfp28_leds" component1="part0" component2="qsfp28_leds">
+      <connection_map name="part0_qsfp28_leds" typical_delay="5" c1_st_index="3" c1_end_index="8" c2_st_index="0" c2_end_index="5"/>
+    </connection>
+    <connection name="part0_uart_msp" component1="part0" component2="uart_msp">
+      <connection_map name="part0_uart_msp" typical_delay="5" c1_st_index="9" c1_end_index="10" c2_st_index="0" c2_end_index="1"/>
+    </connection>
+    <connection name="part0_reset_si5394" component1="part0" component2="reset_si5394">
+      <connection_map name="part0_reset_si5394" typical_delay="5" c1_st_index="11" c1_end_index="11" c2_st_index="0" c2_end_index="0"/>
+    </connection>
+    <connection name="part0_gpio_si5394" component1="part0" component2="gpio_si5394">
+      <connection_map name="part0_gpio_si5394" typical_delay="5" c1_st_index="12" c1_end_index="14" c2_st_index="0" c2_end_index="2"/>
+    </connection>
+    <connection name="part0_msp_gpio" component1="part0" component2="msp_gpio">
+      <connection_map name="part0_msp_gpio" typical_delay="5" c1_st_index="15" c1_end_index="16" c2_st_index="0" c2_end_index="1"/>
+    </connection>
+    <connection name="part0_iic_si5394" component1="part0" component2="iic_si5394">
+      <connection_map name="part0_iic_si5394" typical_delay="5" c1_st_index="100" c1_end_index="101" c2_st_index="0" c2_end_index="1"/>
+    </connection>
+    <connection name="part0_qsfp_161mhz" component1="part0" component2="qsfp_161mhz">
+      <connection_map name="part0_qsfp_161mhz" typical_delay="5" c1_st_index="104" c1_end_index="105" c2_st_index="0" c2_end_index="1"/>
+    </connection>
+    <connection name="part0_qsfp_322mhz" component1="part0" component2="qsfp_322mhz">
+      <connection_map name="part0_qsfp_322mhz" typical_delay="5" c1_st_index="106" c1_end_index="107" c2_st_index="0" c2_end_index="1"/>
+    </connection>
+    <connection name="part0_cmc_clk" component1="part0" component2="cmc_clk">
+      <connection_map name="part0_cmc_clk" typical_delay="5" c1_st_index="108" c1_end_index="109" c2_st_index="0" c2_end_index="1"/>
+    </connection>
+    <connection name="part0_hbm_clk" component1="part0" component2="hbm_clk">
+      <connection_map name="part0_hbm_clk" typical_delay="5" c1_st_index="110" c1_end_index="111" c2_st_index="0" c2_end_index="1"/>
+    </connection>
+    <connection name="part0_pcie_refclk" component1="part0" component2="pcie_refclk">
+      <connection_map name="part0_pcie_refclk" typical_delay="5" c1_st_index="700" c1_end_index="701" c2_st_index="0" c2_end_index="1"/>
+    </connection>
+    <connection name="part0_pci_express" component1="part0" component2="pci_express">
+      <connection_map name="part0_pcie_express_1" c1_st_index="702" c1_end_index="765" c2_st_index="0" c2_end_index="63"/>
+    </connection>
+    <connection name="part0_qsfp_gt" component1="part0" component2="qsfp">
+      <connection_map name="part0_sfpdd_gt" typical_delay="5" c1_st_index="800" c1_end_index="815" c2_st_index="0" c2_end_index="15"/>
+    </connection>
+  </connections>
+  <ip_associated_rules>
+    <ip_associated_rule name="default">
+      <ip vendor="xilinx.com" library="ip" name="xdma" version="*" ip_interface="sys_rst_n">
+        <associated_board_interfaces>
+          <associated_board_interface name="pcie_perstn" order="0"/>
+        </associated_board_interfaces>
+      </ip>
+      <ip vendor="xilinx.com" library="ip" name="pcie4_uscale_plus" version="*" ip_interface="sys_rst_n">
+        <associated_board_interfaces>
+          <associated_board_interface name="pcie_perstn" order="0"/>
+        </associated_board_interfaces>
+      </ip>
+      <ip vendor="xilinx.com" library="ip" name="qdma" version="*" ip_interface="sys_rst_n">
+        <associated_board_interfaces>
+          <associated_board_interface name="pcie_perstn" order="0"/>
+        </associated_board_interfaces>
+      </ip>
+      <ip vendor="xilinx.com" library="ip" name="hbm" version="*" ip_interface="DRAM_0_STAT_CATTRIP">
+        <associated_board_interfaces>
+          <associated_board_interface name="hbm_cattrip" order="0"/>
+        </associated_board_interfaces>
+      </ip>
+      <ip vendor="xilinx.com" library="ip" name="util_ds_buf" version="*" ip_interface="CLK_IN_D">
+        <associated_board_interfaces>
+          <associated_board_interface name="pcie_refclk" order="0"/>
+          <associated_board_interface name="cmc_clk" order="1"/>
+          <associated_board_interface name="hbm_clk" order="2"/>
+        </associated_board_interfaces>
+      </ip>
+      <ip vendor="xilinx.com" library="ip" name="clk_wiz" version="*" ip_interface="CLK_IN_D">
+        <associated_board_interfaces>
+          <associated_board_interface name="cmc_clk" order="0"/>
+          <associated_board_interface name="pcie_refclk" order="1"/>
+          <associated_board_interface name="hbm_clk" order="2"/>
+        </associated_board_interfaces>
+      </ip>
+      <ip vendor="xilinx.com" library="ip" name="xxv_ethernet" version="*" ip_interface="gt_serial_port">
+        <associated_board_interfaces>
+          <associated_board_interface name="qsfp_1x" order="0"/>
+          <associated_board_interface name="qsfp_2x" order="1"/>
+          <associated_board_interface name="qsfp_3x" order="2"/>
+          <associated_board_interface name="qsfp_4x" order="3"/>
+        </associated_board_interfaces>
+      </ip>
+      <ip vendor="xilinx.com" library="ip" name="usxgmii" version="*" ip_interface="gt_serial_port">
+        <associated_board_interfaces>
+          <associated_board_interface name="qsfp_1x" order="0"/>
+          <associated_board_interface name="qsfp_2x" order="1"/>
+          <associated_board_interface name="qsfp_3x" order="2"/>
+          <associated_board_interface name="qsfp_4x" order="3"/>
+        </associated_board_interfaces>
+      </ip>
+      <ip vendor="xilinx.com" library="ip" name="l_ethernet" version="*" ip_interface="gt_serial_port">
+        <associated_board_interfaces>
+          <associated_board_interface name="qsfp_2x" order="0"/>
+          <associated_board_interface name="qsfp_4x" order="1"/>
+        </associated_board_interfaces>
+      </ip>
+      <ip vendor="xilinx.com" library="ip" name="cmac_usplus" version="*" ip_interface="gt_serial_port">
+        <associated_board_interfaces>
+          <associated_board_interface name="qsfp_4x" order="0"/>
+        </associated_board_interfaces>
+      </ip>
+      <ip vendor="xilinx.com" library="ip" name="xxv_ethernet" version="*" ip_interface="gt_ref_clk">
+        <associated_board_interfaces>
+          <associated_board_interface name="qsfp_161mhz" order="0"/>
+          <associated_board_interface name="qsfp_322mhz" order="1"/>
+        </associated_board_interfaces>
+      </ip>
+      <ip vendor="xilinx.com" library="ip" name="usxgmii" version="*" ip_interface="gt_ref_clk">
+        <associated_board_interfaces>
+          <associated_board_interface name="qsfp_161mhz" order="0"/>
+          <associated_board_interface name="qsfp_322mhz" order="1"/>
+        </associated_board_interfaces>
+      </ip>
+      <ip vendor="xilinx.com" library="ip" name="l_ethernet" version="*" ip_interface="gt_ref_clk">
+        <associated_board_interfaces>
+          <associated_board_interface name="qsfp_161mhz" order="0"/>
+          <associated_board_interface name="qsfp_322mhz" order="1"/>
+        </associated_board_interfaces>
+      </ip>
+      <ip vendor="xilinx.com" library="ip" name="cmac_usplus" version="*" ip_interface="gt_ref_clk">
+        <associated_board_interfaces>
+          <associated_board_interface name="qsfp_161mhz" order="0"/>
+          <associated_board_interface name="qsfp_322mhz" order="1"/>
+        </associated_board_interfaces>
+      </ip>
+    </ip_associated_rule>
+  </ip_associated_rules>
+</board>

--- a/toolflow/vivado/common/data/boards/board_files/au50/1.3/changelog.txt
+++ b/toolflow/vivado/common/data/boards/board_files/au50/1.3/changelog.txt
@@ -1,0 +1,9 @@
+######### AU50 change log ##############
+1.0
+AU50 Initial board support
+1.1
+Update the HBM CATTRIP and GUI display
+1.2
+AU50/AU50LV Changed the CMAC and PCIe Quad location settings
+1.3
+Updated logical port type to TRI_O for HBM_CATTRIP

--- a/toolflow/vivado/common/data/boards/board_files/au50/1.3/part0_pins.xml
+++ b/toolflow/vivado/common/data/boards/board_files/au50/1.3/part0_pins.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Copyright (C) 2019, Xilinx Inc - All rights reserved
+ Licensed under the Apache License, Version 2.0 (the "License"). You may
+ not use this file except in compliance with the License. A copy of the
+ License is located at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations
+ under the License. -->
+<part_info part_name="xcu50-fsvh2104-2-e">
+  <pins>
+    <pin index="0" name="PCIE_PERSTN" iostandard="LVCMOS18" loc="AW27"/>
+    <pin index="1" name="PEX_PWRBRKN" iostandard="LVCMOS18" loc="BD28"/>
+    <pin index="2" name="HBM_CATTRIP" iostandard="LVCMOS18" loc="J18"/>
+    <pin index="3" name="QSFP28_0_ACTIVITY_LED" iostandard="LVCMOS18" loc="E18" drive="8"/>
+    <pin index="4" name="QSFP28_0_STATUS_LEDG" iostandard="LVCMOS18" loc="E16" drive="8"/>
+    <pin index="5" name="QSFP28_0_STATUS_LEDY" iostandard="LVCMOS18" loc="F17" drive="8"/>
+    <pin index="6" name="QSFP28_1_ACTIVITY_LED" iostandard="LVCMOS18" loc="E15" drive="8"/>
+    <pin index="7" name="QSFP28_1_STATUS_LEDG" iostandard="LVCMOS18" loc="F15" drive="8"/>
+    <pin index="8" name="QSFP28_1_STATUS_LEDY" iostandard="LVCMOS18" loc="E17" drive="8"/>
+    <pin index="9" name="FPGA_TXD_MSP" iostandard="LVCMOS18" loc="BB25"/>
+    <pin index="10" name="FPGA_RXD_MSP" iostandard="LVCMOS18" loc="BB26"/>
+    <pin index="11" name="SI_RSTBB" iostandard="LVCMOS18" loc="F20"/>
+    <pin index="12" name="SI_INTRB" iostandard="LVCMOS18" loc="H18"/>
+    <pin index="13" name="SI_PLL_LOCK" iostandard="LVCMOS18" loc="G19"/>
+    <pin index="14" name="SI_IN_LOS" iostandard="LVCMOS18" loc="H19"/>
+    <pin index="15" name="GPIO_MSP0" iostandard="LVCMOS18" loc="C16"/>
+    <pin index="16" name="GPIO_MSP1" iostandard="LVCMOS18" loc="C17"/>
+    <pin index="100" name="I2C_SI5394_SCLK" iostandard="LVCMOS18" loc="L19" drive="8" slew="SLOW"/>
+    <pin index="101" name="I2C_SI5394_SDA" iostandard="LVCMOS18" loc="J16" drive="8" slew="SLOW"/>
+    <pin index="102" name="ETH_RECOVERED_CLK_P" iostandard="LVDS" loc="F19"/>
+    <pin index="103" name="ETH_RECOVERED_CLK_N" iostandard="LVDS" loc="F18"/>
+    <pin index="104" name="SYNCE_CLK_P" iostandard="LVDS" loc="N36"/>
+    <pin index="105" name="SYNCE_CLK_N" iostandard="LVDS" loc="N37"/>
+    <pin index="106" name="CLK_1588_P" iostandard="LVDS" loc="M38"/>
+    <pin index="107" name="CLK_1588_N" iostandard="LVDS" loc="M39"/>
+    <pin index="108" name="SYSCLK2_P" iostandard="LVDS" loc="G17"/>
+    <pin index="109" name="SYSCLK2_N" iostandard="LVDS" loc="G16"/>
+    <pin index="110" name="SYSCLK3_P" iostandard="LVDS" loc="BB18"/>
+    <pin index="111" name="SYSCLK3_N" iostandard="LVDS" loc="BC18"/>
+    <pin index="700" name="PCIE_REFCLK1_N" iostandard="LVDS" loc="AF8"/>
+    <pin index="701" name="PCIE_REFCLK1_P" iostandard="LVDS" loc="AF9"/>
+    <pin index="702" name="pcie_rx0_n" loc="AL1"/>
+    <pin index="703" name="pcie_rx0_p" loc="AL2"/>
+    <pin index="704" name="pcie_rx1_n" loc="AM3"/>
+    <pin index="705" name="pcie_rx1_p" loc="AM4"/>
+    <pin index="706" name="pcie_rx2_n" loc="AK3"/>
+    <pin index="707" name="pcie_rx2_p" loc="AK4"/>
+    <pin index="708" name="pcie_rx3_n" loc="AN1"/>
+    <pin index="709" name="pcie_rx3_p" loc="AN2"/>
+    <pin index="710" name="pcie_rx4_n" loc="AP3"/>
+    <pin index="711" name="pcie_rx4_p" loc="AP4"/>
+    <pin index="712" name="pcie_rx5_n" loc="AR1"/>
+    <pin index="713" name="pcie_rx5_p" loc="AR2"/>
+    <pin index="714" name="pcie_rx6_n" loc="AT3"/>
+    <pin index="715" name="pcie_rx6_p" loc="AT4"/>
+    <pin index="716" name="pcie_rx7_n" loc="AU1"/>
+    <pin index="717" name="pcie_rx7_p" loc="AU2"/>
+    <pin index="718" name="pcie_rx8_n" loc="AV3"/>
+    <pin index="719" name="pcie_rx8_p" loc="AV4"/>
+    <pin index="720" name="pcie_rx9_n" loc="AW1"/>
+    <pin index="721" name="pcie_rx9_p" loc="AW2"/>
+    <pin index="722" name="pcie_rx10_n" loc="BA1"/>
+    <pin index="723" name="pcie_rx10_p" loc="BA2"/>
+    <pin index="724" name="pcie_rx11_n" loc="BC1"/>
+    <pin index="725" name="pcie_rx11_p" loc="BC2"/>
+    <pin index="726" name="pcie_rx12_n" loc="AY3"/>
+    <pin index="727" name="pcie_rx12_p" loc="AY4"/>
+    <pin index="728" name="pcie_rx13_n" loc="BB3"/>
+    <pin index="729" name="pcie_rx13_p" loc="BB4"/>
+    <pin index="730" name="pcie_rx14_n" loc="BD3"/>
+    <pin index="731" name="pcie_rx14_p" loc="BD4"/>
+    <pin index="732" name="pcie_rx15_n" loc="BE5"/>
+    <pin index="733" name="pcie_rx15_p" loc="BE6"/>
+    <pin index="734" name="pcie_tx0_n" loc="Y4"/>
+    <pin index="735" name="pcie_tx0_p" loc="Y5"/>
+    <pin index="736" name="pcie_tx1_n" loc="AA6"/>
+    <pin index="737" name="pcie_tx1_p" loc="AA7"/>
+    <pin index="738" name="pcie_tx2_n" loc="AB4"/>
+    <pin index="739" name="pcie_tx2_p" loc="AB5"/>
+    <pin index="740" name="pcie_tx3_n" loc="AC6"/>
+    <pin index="741" name="pcie_tx3_p" loc="AC7"/>
+    <pin index="742" name="pcie_tx4_n" loc="AD4"/>
+    <pin index="743" name="pcie_tx4_p" loc="AD5"/>
+    <pin index="744" name="pcie_tx5_n" loc="AF4"/>
+    <pin index="745" name="pcie_tx5_p" loc="AF5"/>
+    <pin index="746" name="pcie_tx6_n" loc="AE6"/>
+    <pin index="747" name="pcie_tx6_p" loc="AE7"/>
+    <pin index="748" name="pcie_tx7_n" loc="AH4"/>
+    <pin index="749" name="pcie_tx7_p" loc="AH5"/>
+    <pin index="750" name="pcie_tx8_n" loc="AG6"/>
+    <pin index="751" name="pcie_tx8_p" loc="AG7"/>
+    <pin index="752" name="pcie_tx9_n" loc="AJ6"/>
+    <pin index="753" name="pcie_tx9_p" loc="AJ7"/>
+    <pin index="754" name="pcie_tx10_n" loc="AL6"/>
+    <pin index="755" name="pcie_tx10_p" loc="AL7"/>
+    <pin index="756" name="pcie_tx11_n" loc="AM8"/>
+    <pin index="757" name="pcie_tx11_p" loc="AM9"/>
+    <pin index="758" name="pcie_tx12_n" loc="AN6"/>
+    <pin index="759" name="pcie_tx12_p" loc="AN7"/>
+    <pin index="760" name="pcie_tx13_n" loc="AP8"/>
+    <pin index="761" name="pcie_tx13_p" loc="AP9"/>
+    <pin index="762" name="pcie_tx14_n" loc="AR6"/>
+    <pin index="763" name="pcie_tx14_p" loc="AR7"/>
+    <pin index="764" name="pcie_tx15_n" loc="AT8"/>
+    <pin index="765" name="pcie_tx15_p" loc="AT9"/>
+    <pin index="800" name="QSFP28_0_TX_P0" loc="D42"/>
+    <pin index="801" name="QSFP28_0_TX_N0" loc="D43"/>
+    <pin index="802" name="QSFP28_0_RX_P0" loc="J45"/>
+    <pin index="803" name="QSFP28_0_RX_N0" loc="J46"/>
+    <pin index="804" name="QSFP28_0_TX_P1" loc="C40"/>
+    <pin index="805" name="QSFP28_0_TX_N1" loc="C41"/>
+    <pin index="806" name="QSFP28_0_RX_P1" loc="G45"/>
+    <pin index="807" name="QSFP28_0_RX_N1" loc="G46"/>
+    <pin index="808" name="QSFP28_0_TX_P2" loc="B42"/>
+    <pin index="809" name="QSFP28_0_TX_N2" loc="B43"/>
+    <pin index="810" name="QSFP28_0_RX_P2" loc="F43"/>
+    <pin index="811" name="QSFP28_0_RX_N2" loc="F44"/>
+    <pin index="812" name="QSFP28_0_TX_P3" loc="A40"/>
+    <pin index="813" name="QSFP28_0_TX_N3" loc="A41"/>
+    <pin index="814" name="QSFP28_0_RX_P3" loc="E45"/>
+    <pin index="815" name="QSFP28_0_RX_N3" loc="E46"/>
+  </pins>
+</part_info>

--- a/toolflow/vivado/common/data/boards/board_files/au50/1.3/preset.xml
+++ b/toolflow/vivado/common/data/boards/board_files/au50/1.3/preset.xml
@@ -1,0 +1,361 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!-- Copyright (C) 2019, Xilinx Inc - All rights reserved
+ Licensed under the Apache License, Version 2.0 (the "License"). You may
+ not use this file except in compliance with the License. A copy of the
+ License is located at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ License for the specific language governing permissions and limitations
+ under the License. -->
+<ip_presets schema="1.0">
+
+
+   <ip_preset preset_proc_name="reset_si5394_preset">
+    <ip vendor="xilinx.com" library="ip" name="axi_gpio">
+      <user_parameters>
+        <user_parameter name="CONFIG.C_DOUT_DEFAULT" value="0x00000001"/>
+      </user_parameters>
+    </ip>
+  </ip_preset>
+
+   <ip_preset preset_proc_name="reset2_si5394_preset">
+    <ip vendor="xilinx.com" library="ip" name="axi_gpio">
+      <user_parameters>
+        <user_parameter name="CONFIG.C_DOUT_DEFAULT_2" value="0x00000001"/>
+      </user_parameters>
+    </ip>
+  </ip_preset>
+
+   <ip_preset preset_proc_name="pcie_refclk_preset">
+    <ip vendor="xilinx.com" library="ip" name="util_ds_buf">
+      <user_parameters>
+        <user_parameter name="CONFIG.C_BUF_TYPE" value="IBUFDSGTE" />
+        <user_parameter name="CONFIG.C_SIZE" value="1" />
+      </user_parameters>
+    </ip>
+  </ip_preset>
+
+
+   <ip_preset preset_proc_name="pciex1_preset">
+
+    <ip vendor="xilinx.com" library="ip" name="xdma">
+      <user_parameters>
+        <user_parameter name="CONFIG.pl_link_cap_max_link_width" value="X1" />
+		<user_parameter name="CONFIG.pl_link_cap_max_link_speed" value="8.0_GT/s" />
+		<user_parameter name="CONFIG.mode_selection" value="Advanced" />
+		<user_parameter name="CONFIG.en_gt_selection" value="true" />
+	    <user_parameter name="CONFIG.select_quad" value="GTY_Quad_227" />
+      </user_parameters>
+    </ip>
+
+	<ip vendor="xilinx.com" library="ip" name="qdma">
+      <user_parameters>
+        <user_parameter name="CONFIG.pl_link_cap_max_link_width" value="X1" />
+		<user_parameter name="CONFIG.pl_link_cap_max_link_speed" value="8.0_GT/s" />
+		<user_parameter name="CONFIG.mode_selection" value="Advanced" />
+		<user_parameter name="CONFIG.en_gt_selection" value="true" />
+	    <user_parameter name="CONFIG.select_quad" value="GTY_Quad_227" />
+      </user_parameters>
+    </ip>
+
+	<ip vendor="xilinx.com" library="ip" name="pcie4c_uscale_plus">
+		<user_parameters>
+			<user_parameter name="CONFIG.pl_link_cap_max_link_speed" value="8.0_GT/s" />
+			<user_parameter name="CONFIG.pl_link_cap_max_link_width" value="X1" />
+			<user_parameter name="CONFIG.mode_selection" value="Advanced" />
+			<user_parameter name="CONFIG.en_gt_selection" value="true" />
+			<user_parameter name="CONFIG.select_quad" value="GTY_Quad_227" />
+		</user_parameters>
+	</ip>
+
+  </ip_preset>
+
+  <ip_preset preset_proc_name="pciex2_preset">
+
+    <ip vendor="xilinx.com" library="ip" name="xdma">
+      <user_parameters>
+	    <user_parameter name="CONFIG.pl_link_cap_max_link_speed" value="8.0_GT/s" />
+        <user_parameter name="CONFIG.pl_link_cap_max_link_width" value="X2" />
+		<user_parameter name="CONFIG.mode_selection" value="Advanced" />
+		<user_parameter name="CONFIG.en_gt_selection" value="true" />
+	    <user_parameter name="CONFIG.select_quad" value="GTY_Quad_227" />
+      </user_parameters>
+    </ip>
+
+    <ip vendor="xilinx.com" library="ip" name="qdma">
+      <user_parameters>
+	    <user_parameter name="CONFIG.pl_link_cap_max_link_speed" value="8.0_GT/s" />
+        <user_parameter name="CONFIG.pl_link_cap_max_link_width" value="X2" />
+		<user_parameter name="CONFIG.mode_selection" value="Advanced" />
+		<user_parameter name="CONFIG.en_gt_selection" value="true" />
+	    <user_parameter name="CONFIG.select_quad" value="GTY_Quad_227" />
+      </user_parameters>
+    </ip>
+
+	<ip vendor="xilinx.com" library="ip" name="pcie4c_uscale_plus">
+		<user_parameters>
+		    <!-- <user_parameter name="CONFIG.pcie_blk_locn" value="X1Y1" /> -->
+			<user_parameter name="CONFIG.pl_link_cap_max_link_speed" value="8.0_GT/s" />
+			<user_parameter name="CONFIG.pl_link_cap_max_link_width" value="X2" />
+			<user_parameter name="CONFIG.mode_selection" value="Advanced" />
+			<user_parameter name="CONFIG.en_gt_selection" value="true" />
+			<user_parameter name="CONFIG.select_quad" value="GTY_Quad_227" />
+		</user_parameters>
+	</ip>
+
+
+  </ip_preset>
+
+  <ip_preset preset_proc_name="pciex4_preset">
+    <ip vendor="xilinx.com" library="ip" name="xdma">
+      <user_parameters>
+	    <user_parameter name="CONFIG.pl_link_cap_max_link_speed" value="8.0_GT/s" />
+        <user_parameter name="CONFIG.pl_link_cap_max_link_width" value="X4" />
+		<user_parameter name="CONFIG.mode_selection" value="Advanced" />
+		<user_parameter name="CONFIG.en_gt_selection" value="true" />
+	    <user_parameter name="CONFIG.select_quad" value="GTY_Quad_227" />
+      </user_parameters>
+    </ip>
+
+    <ip vendor="xilinx.com" library="ip" name="qdma">
+      <user_parameters>
+	    <user_parameter name="CONFIG.pl_link_cap_max_link_speed" value="8.0_GT/s" />
+        <user_parameter name="CONFIG.pl_link_cap_max_link_width" value="X4" />
+		<user_parameter name="CONFIG.mode_selection" value="Advanced" />
+		<user_parameter name="CONFIG.en_gt_selection" value="true" />
+	    <user_parameter name="CONFIG.select_quad" value="GTY_Quad_227" />
+      </user_parameters>
+    </ip>
+
+
+	<ip vendor="xilinx.com" library="ip" name="pcie4c_uscale_plus">
+		<user_parameters>
+		    <!-- <user_parameter name="CONFIG.pcie_blk_locn" value="X1Y1" /> -->
+			<user_parameter name="CONFIG.pl_link_cap_max_link_speed" value="8.0_GT/s" />
+			<user_parameter name="CONFIG.pl_link_cap_max_link_width" value="X4" />
+			<user_parameter name="CONFIG.mode_selection" value="Advanced" />
+			<user_parameter name="CONFIG.en_gt_selection" value="true" />
+			<user_parameter name="CONFIG.select_quad" value="GTY_Quad_227" />
+		</user_parameters>
+	</ip>
+
+
+  </ip_preset>
+
+   <ip_preset preset_proc_name="pciex8_preset">
+    <ip vendor="xilinx.com" library="ip" name="xdma">
+      <user_parameters>
+
+	    <user_parameter name="CONFIG.pl_link_cap_max_link_speed" value="8.0_GT/s" />
+        <user_parameter name="CONFIG.pl_link_cap_max_link_width" value="X8" />
+		<user_parameter name="CONFIG.mode_selection" value="Advanced" />
+		<user_parameter name="CONFIG.en_gt_selection" value="true" />
+	    <user_parameter name="CONFIG.select_quad" value="GTY_Quad_227" />
+      </user_parameters>
+     </ip>
+
+    <ip vendor="xilinx.com" library="ip" name="qdma">
+      <user_parameters>
+	    <user_parameter name="CONFIG.pl_link_cap_max_link_speed" value="8.0_GT/s" />
+        <user_parameter name="CONFIG.pl_link_cap_max_link_width" value="X8" />
+		<user_parameter name="CONFIG.mode_selection" value="Advanced" />
+		<user_parameter name="CONFIG.en_gt_selection" value="true" />
+	    <user_parameter name="CONFIG.select_quad" value="GTY_Quad_227" />
+      </user_parameters>
+     </ip>
+
+	<ip vendor="xilinx.com" library="ip" name="pcie4c_uscale_plus">
+		<user_parameters>
+
+		    <!-- <user_parameter name="CONFIG.pcie_blk_locn" value="X1Y1" /> -->
+			<user_parameter name="CONFIG.pl_link_cap_max_link_speed" value="8.0_GT/s" />
+			<user_parameter name="CONFIG.pl_link_cap_max_link_width" value="X8" />
+			<user_parameter name="CONFIG.mode_selection" value="Advanced" />
+			<user_parameter name="CONFIG.en_gt_selection" value="true" />
+			<user_parameter name="CONFIG.select_quad" value="GTY_Quad_227" />
+		</user_parameters>
+	</ip>
+
+
+  </ip_preset>
+
+   <ip_preset preset_proc_name="pciex16_preset">
+    <ip vendor="xilinx.com" library="ip" name="xdma">
+      <user_parameters>
+	    <user_parameter name="CONFIG.pl_link_cap_max_link_speed" value="8.0_GT/s" />
+        <user_parameter name="CONFIG.pl_link_cap_max_link_width" value="X16" />
+		<user_parameter name="CONFIG.mode_selection" value="Advanced" />
+		<user_parameter name="CONFIG.en_gt_selection" value="true" />
+	    <user_parameter name="CONFIG.select_quad" value="GTY_Quad_227" />
+      </user_parameters>
+     </ip>
+
+    <ip vendor="xilinx.com" library="ip" name="qdma">
+      <user_parameters>
+	    <user_parameter name="CONFIG.pl_link_cap_max_link_speed" value="8.0_GT/s" />
+        <user_parameter name="CONFIG.pl_link_cap_max_link_width" value="X16" />
+		<user_parameter name="CONFIG.mode_selection" value="Advanced" />
+		<user_parameter name="CONFIG.en_gt_selection" value="true" />
+	    <user_parameter name="CONFIG.select_quad" value="GTY_Quad_227" />
+      </user_parameters>
+     </ip>
+
+	<ip vendor="xilinx.com" library="ip" name="pcie4c_uscale_plus">
+		<user_parameters>
+
+			<!-- <user_parameter name="CONFIG.pcie_blk_locn" value="X1Y1" />				 -->
+			<user_parameter name="CONFIG.pl_link_cap_max_link_speed" value="8.0_GT/s" />
+			<user_parameter name="CONFIG.pl_link_cap_max_link_width" value="X16" />
+			<user_parameter name="CONFIG.mode_selection" value="Advanced" />
+			<user_parameter name="CONFIG.en_gt_selection" value="true" />
+			<user_parameter name="CONFIG.select_quad" value="GTY_Quad_227" />
+		</user_parameters>
+	</ip>
+
+  </ip_preset>
+
+   <ip_preset preset_proc_name="default_300mhz_clk0_preset">
+    <ip vendor="xilinx.com" library="ip" name="clk_wiz" ip_interface="CLK_IN1_D">
+        <user_parameters>
+          <user_parameter name="CONFIG.PRIM_IN_FREQ" value="300"/>
+          <user_parameter name="CONFIG.PRIM_SOURCE" value="Differential_clock_capable_pin"/>
+        </user_parameters>
+    </ip>
+    <ip vendor="xilinx.com" library="ip" name="util_ds_buf">
+        <user_parameters>
+        <user_parameter name="CONFIG.C_BUF_TYPE" value="IBUFDS" />
+        <user_parameter name="CONFIG.C_SIZE" value="1" />
+        </user_parameters>
+    </ip>
+  </ip_preset>
+
+  <!-- QSFP0 Connector -->
+
+      <ip_preset preset_proc_name="qsfp0_1x_preset">
+
+ 		<ip vendor="xilinx.com" library="ip" name="xxv_ethernet">
+ 		  <user_parameters>
+ 			<!-- <user_parameter name="CONFIG.GT_REF_CLK_FREQ" value="161.1328125" /> -->
+ 			<user_parameter name="CONFIG.NUM_OF_CORES" value="1" />
+ 			<user_parameter name="CONFIG.GT_TYPE" value="GTY" />
+ 			<user_parameter name="CONFIG.LINE_RATE" value="10" />
+ 			<user_parameter name="CONFIG.GT_GROUP_SELECT" value="Quad_X0Y7" />
+ 			<user_parameter name="CONFIG.BASE_R_KR" value="BASE-R" />
+ 		  </user_parameters>
+ 		</ip>
+
+ 		<ip vendor="xilinx.com" library="ip" name="usxgmii">
+ 		  <user_parameters>
+ 			<user_parameter name="CONFIG.NUM_OF_CORES" value="1" />
+ 			<user_parameter name="CONFIG.GT_TYPE" value="GTY" />
+ 			<user_parameter name="CONFIG.GT_GROUP_SELECT" value="Quad_X0Y7" />
+ 		  </user_parameters>
+ 		</ip>
+
+
+      </ip_preset>
+
+     <ip_preset preset_proc_name="qsfp0_2x_preset">
+
+ 	   <ip vendor="xilinx.com" library="ip" name="xxv_ethernet">
+ 		  <user_parameters>
+ 			<user_parameter name="CONFIG.NUM_OF_CORES" value="2" />
+ 			<user_parameter name="CONFIG.GT_TYPE" value="GTY" />
+ 			<user_parameter name="CONFIG.LINE_RATE" value="10" />
+ 			<user_parameter name="CONFIG.GT_GROUP_SELECT" value="Quad_X0Y7" />
+ 			<user_parameter name="CONFIG.BASE_R_KR" value="BASE-R" />
+ 		  </user_parameters>
+ 		</ip>
+
+ 		<ip vendor="xilinx.com" library="ip" name="usxgmii">
+ 		  <user_parameters>
+ 			<user_parameter name="CONFIG.NUM_OF_CORES" value="2" />
+ 			<user_parameter name="CONFIG.GT_TYPE" value="GTY" />
+ 			<user_parameter name="CONFIG.GT_GROUP_SELECT" value="Quad_X0Y7" />
+ 		  </user_parameters>
+ 		</ip>
+
+ 		<ip vendor="xilinx.com" library="ip" name="l_ethernet">
+ 		  <user_parameters>
+ 			<!-- <user_parameter name="CONFIG.GT_REF_CLK_FREQ" value="161.1328125" /> -->
+ 			<user_parameter name="CONFIG.LINE_RATE" value="40" />
+ 			<user_parameter name="CONFIG.GT_TYPE" value="GTY" />
+ 			<user_parameter name="CONFIG.GT_GROUP_SELECT" value="Quad_X0Y7" />
+ 			<user_parameter name="CONFIG.BASE_R_KR" value="BASE-R" />
+ 		  </user_parameters>
+ 		</ip>
+
+
+   </ip_preset>
+
+    <ip_preset preset_proc_name="qsfp0_3x_preset">
+
+ 		<ip vendor="xilinx.com" library="ip" name="xxv_ethernet">
+ 		  <user_parameters>
+ 			<user_parameter name="CONFIG.NUM_OF_CORES" value="3" />
+ 			<user_parameter name="CONFIG.GT_TYPE" value="GTY" />
+ 			<user_parameter name="CONFIG.LINE_RATE" value="10" />
+ 			<user_parameter name="CONFIG.GT_GROUP_SELECT" value="Quad_X0Y7" />
+ 			<user_parameter name="CONFIG.BASE_R_KR" value="BASE-R" />
+ 		  </user_parameters>
+ 		</ip>
+
+ 		<ip vendor="xilinx.com" library="ip" name="usxgmii">
+ 		  <user_parameters>
+ 			<user_parameter name="CONFIG.NUM_OF_CORES" value="3" />
+ 			<user_parameter name="CONFIG.GT_TYPE" value="GTY" />
+ 			<user_parameter name="CONFIG.GT_GROUP_SELECT" value="Quad_X0Y7" />
+ 		  </user_parameters>
+ 		</ip>
+
+     </ip_preset>
+
+    <ip_preset preset_proc_name="qsfp0_4x_preset">
+
+ 		<ip vendor="xilinx.com" library="ip" name="xxv_ethernet">
+ 		  <user_parameters>
+ 				<user_parameter name="CONFIG.NUM_OF_CORES" value="4" />
+ 				<user_parameter name="CONFIG.GT_TYPE" value="GTY" />
+ 				<user_parameter name="CONFIG.LINE_RATE" value="10" />
+ 				<user_parameter name="CONFIG.GT_GROUP_SELECT" value="Quad_X0Y7" />
+ 				<user_parameter name="CONFIG.BASE_R_KR" value="BASE-R" />
+ 		  </user_parameters>
+ 		</ip>
+
+ 		<ip vendor="xilinx.com" library="ip" name="usxgmii">
+ 		  <user_parameters>
+ 			<user_parameter name="CONFIG.NUM_OF_CORES" value="4" />
+ 			<user_parameter name="CONFIG.GT_TYPE" value="GTY" />
+ 			<user_parameter name="CONFIG.GT_GROUP_SELECT" value="Quad_X0Y7" />
+ 		  </user_parameters>
+ 		</ip>
+
+
+ 		<ip vendor="xilinx.com" library="ip" name="l_ethernet">
+ 		  <user_parameters>
+ 			<!-- <user_parameter name="CONFIG.GT_REF_CLK_FREQ" value="161.1328125" /> -->
+ 				<user_parameter name="CONFIG.LINE_RATE" value="40" />
+ 				<user_parameter name="CONFIG.GT_TYPE" value="GTY" />
+ 				<user_parameter name="CONFIG.GT_GROUP_SELECT" value="Quad_X0Y7" />
+ 				<user_parameter name="CONFIG.BASE_R_KR" value="BASE-R" />
+ 		  </user_parameters>
+ 		</ip>
+
+ 		<ip vendor="xilinx.com" library="ip" name="cmac_usplus">
+ 		  <user_parameters>
+ 			<!--<user_parameter name="CONFIG.GT_REF_CLK_FREQ" value="161.1328125" />-->
+ 			<user_parameter name="CONFIG.GT_TYPE" value="GTY" />
+ 			<user_parameter name="CONFIG.CMAC_CAUI4_MODE" value="1" />
+ 			<user_parameter name="CONFIG.NUM_LANES" value="4x25" />
+ 			<user_parameter name="CONFIG.CMAC_CORE_SELECT" value="CMACE4_X0Y4" />
+ 			<!--<user_parameter name="CONFIG.GT_GROUP_SELECT" value= "Quad_X0Y7" />-->
+ 			<user_parameter name="CONFIG.GT_GROUP_SELECT" value= "X0Y28~X0Y31" />
+ 			<user_parameter name="CONFIG.RS_FEC_TRANSCODE_BYPASS" value= "0" />
+ 		  </user_parameters>
+ 		</ip>
+
+   </ip_preset>
+
+</ip_presets>

--- a/toolflow/vivado/platform/AU50/AU50.tcl
+++ b/toolflow/vivado/platform/AU50/AU50.tcl
@@ -28,32 +28,94 @@ namespace eval platform {
 
   source $::env(TAPASCO_HOME_TCL)/platform/pcie/pcie_base.tcl
 
-  proc get_ignored_segments { } {
-    set ignored [list]
-    set axi_index "23"
-    for {set j 0} {$j < 32} {incr j} {
-      set mem_index [format %02s $j]
-      lappend ignored "/memory/mig/mig_internal/SAXI_${axi_index}/HBM_MEM${mem_index}"
+  # distribute 128 PEs over 31 AXIs
+  proc max_masters {} {
+    set masters [list]
+    for {set i 0} {$i < 31} {incr i} {
+      if {$i < 4} {
+        set masters [lappend masters 5]
+      } else {
+        set masters [lappend masters 4]
+      }
     }
-    return $ignored
+    return $masters
   }
 
-  proc set_addressmap_AU50 {{args {}}} {
-    for {set i 0} {$i < 32} {incr i} {
-      assign_bd_address [get_bd_addr_segs memory/mig/mig_internal/SAXI_23/HBM_MEM[format %02s $i]]
+  # put HBM segments on ignore list and assign them manually
+  if {![tapasco::is_feature_enabled "SVM"]} {
+    proc get_ignored_segments {} {
+      puts "Running get_ignored_segments from AU50"
+      set num_masters [llength [::arch::get_masters]]
+      set ignored [list]
+      for {set i 0} {$i < 32} {incr i} {
+        set axi_index [format %02s $i]
+        if {$i < $num_masters || $i == 31} {
+          for {set j 0} {$j < 32} {incr j} {
+            set mem_index [format %02s $j]
+            lappend ignored "/memory/hbm_0/SAXI_${axi_index}/HBM_MEM${mem_index}"
+          }
+        }
+      }
+      return $ignored
     }
-    return $args
+
+    proc set_addressmap_AU50 {{args {}}} {
+      set num_masters [llength [::arch::get_masters]]
+      for {set i 0} {$i < 32} {incr i} {
+        set axi_index [format %02s $i]
+        if {$i < $num_masters || $i == 31} {
+          for {set j 0} {$j < 32} {incr j} {
+            set mem_index [format %02s $j]
+            assign_bd_address [get_bd_addr_segs memory/hbm_0/SAXI_${axi_index}/HBM_MEM${mem_index}]
+          }
+        }
+      }
+
+      # add additional PE masters to address map
+      for {set i 1} {$i < $num_masters} {incr i} {
+        set name "M_MEM_$i"
+        set args [lappend args $name [list 0 0 0 ""]]
+      }
+      return $args
+    }
   }
 
-  proc create_mig_core {name} {
-    puts "Creating HBM controllers ..."
+  proc create_subsystem_memory {} {
+    save_bd_design
+    set num_masters [llength [::arch::get_masters]]
 
-    set old_inst [current_bd_instance .]
-    set mig [create_bd_cell -type hier ${name}]
-    current_bd_instance $mig
+    # create hierarchical interface ports
+    for {set i 0} {$i < $num_masters} {incr i} {
+      set s_axi_mem [create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 "S_MEM_$i"]
+    }
+    set m_axi_mem [create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:aximm_rtl:1.0 "M_HOST"]
+    set s_axi_dma [create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 "S_DMA"]
 
-    set hbm [tapasco::ip::create_hbm ${name}_internal]
+    # create hierarchical ports: clocks
+    set ddr_aclk [create_bd_pin -type "clk" -dir "O" "ddr_aclk"]
+    set design_clk [create_bd_pin -type "clk" -dir "O" "design_aclk"]
+    set pcie_aclk [tapasco::subsystem::get_port "host" "clk"]
+    set design_aclk [tapasco::subsystem::get_port "design" "clk"]
 
+    # create hierarchical ports: resets
+    set ddr_aresetn [create_bd_pin -type "rst" -dir "O" "ddr_aresetn"]
+    set design_aresetn [create_bd_pin -type "rst" -dir "O" "design_aresetn"]
+    set pcie_p_aresetn [tapasco::subsystem::get_port "host" "rst" "peripheral" "resetn"]
+    set ddr_ic_aresetn [tapasco::subsystem::get_port "mem" "rst" "interconnect"]
+    set ddr_p_aresetn  [tapasco::subsystem::get_port "mem" "rst" "peripheral" "resetn"]
+    set design_p_aresetn [tapasco::subsystem::get_port "design" "rst" "peripheral" "resetn"]
+
+    variable pcie_width
+    if { $pcie_width == "x8" } {
+      set dma [tapasco::ip::create_bluedma "dma"]
+    } else {
+      set dma [tapasco::ip::create_bluedma_x16 "dma"]
+    }
+    connect_bd_net [get_bd_pins $dma/IRQ_read] [::tapasco::ip::add_interrupt "PLATFORM_COMPONENT_DMA0_READ" "host"]
+    connect_bd_net [get_bd_pins $dma/IRQ_write] [::tapasco::ip::add_interrupt "PLATFORM_COMPONENT_DMA0_WRITE" "host"]
+
+    # instantiate HBM
+    set hbm [tapasco::ip::create_hbm "hbm_0"]
     set hbm_properties [list \
       CONFIG.USER_APB_EN {false} \
       CONFIG.USER_SWITCH_ENABLE_00 {true} \
@@ -61,84 +123,136 @@ namespace eval platform {
       CONFIG.USER_AXI_INPUT_CLK_FREQ [tapasco::get_mem_frequency] \
       CONFIG.USER_XSDB_INTF_EN {TRUE} \
       CONFIG.USER_HBM_DENSITY {8GB} \
+      CONFIG.USER_CLK_SEL_LIST1 {AXI_31_ACLK} \
     ]
 
-    for {set i 0} {$i < 32} {incr i} {
+    # disable HBM ports if we have less than 31 PEs
+    for {set i $num_masters} {$i < 31} {incr i} {
       set saxi [format %02s $i]
-      if {$i != 23} {
-        lappend hbm_properties CONFIG.USER_SAXI_${saxi} {false}
-      }
+      lappend hbm_properties CONFIG.USER_SAXI_${saxi} {false}
     }
 
     for {set i 0} {$i < 32} {incr i} {
       if [expr {($i %2) == 0}] {
         set mc [format %s [expr {$i / 2}]]
         lappend hbm_properties CONFIG.USER_MC${mc}_ECC_BYPASS true
-        # lappend hbm_properties CONFIG.USER_MC${mc}_ECC_CORRECTION false
         lappend hbm_properties CONFIG.USER_MC${mc}_EN_DATA_MASK true
         lappend hbm_properties CONFIG.USER_MC${mc}_TRAFFIC_OPTION {Linear}
         lappend hbm_properties CONFIG.USER_MC${mc}_BG_INTERLEAVE_EN true
       }
     }
-
     set_property -dict $hbm_properties $hbm
 
+    # create clocks and resets
     set hbm_clk_buf [tapasco::ip::create_util_buf hbm_clk_buf]
     apply_board_connection -board_interface "hbm_clk" -ip_intf "${hbm_clk_buf}/CLK_IN_D" -diagram "system"
     connect_bd_net [get_bd_pins ${hbm_clk_buf}/IBUF_OUT] [get_bd_pins ${hbm}/HBM_REF_CLK_0]
     connect_bd_net [get_bd_pins ${hbm_clk_buf}/IBUF_OUT] [get_bd_pins ${hbm}/HBM_REF_CLK_1]
 
+    # generate clocks:
+    # 1. Memory clock (300 MHz)
+    # 2. Design clock (design frequency)
+    # 3. HBM clock (450 MHz)
     set memory_clk_wiz [tapasco::ip::create_clk_wiz memory_clk_wiz]
-    set_property -dict [list CONFIG.CLK_OUT1_PORT {memory_clk} \
-      CONFIG.USE_SAFE_CLOCK_STARTUP {false} \
+    set_property -dict [list CONFIG.NUM_OUT_CLKS {3} \
+      CONFIG.CLK_OUT1_PORT {memory_clk} \
       CONFIG.CLKOUT1_REQUESTED_OUT_FREQ [tapasco::get_mem_frequency] \
+      CONFIG.CLKOUT2_USED {true} \
+      CONFIG.CLK_OUT2_PORT {design_clk} \
+      CONFIG.CLKOUT2_REQUESTED_OUT_FREQ [tapasco::get_design_frequency] \
+      CONFIG.CLKOUT3_USED {true} \
+      CONFIG.CLK_OUT3_PORT {hbm_clk} \
+      CONFIG.CLKOUT3_REQUESTED_OUT_FREQ {450.000} \
+      CONFIG.USE_SAFE_CLOCK_STARTUP {false} \
       CONFIG.USE_LOCKED {true} \
       CONFIG.USE_RESET {false}] $memory_clk_wiz
-
-    set rst_gen [tapasco::ip::create_rst_gen "apb_rst_gen"]
-    connect_bd_net [get_bd_pins ${hbm_clk_buf}/IBUF_OUT] [get_bd_pins $hbm/APB_0_PCLK]
-    connect_bd_net [get_bd_pins $rst_gen/peripheral_aresetn] [get_bd_pins $hbm/APB_0_PRESET_N]
-    connect_bd_net [get_bd_pins ${hbm_clk_buf}/IBUF_OUT] [get_bd_pins $hbm/APB_1_PCLK]
-    connect_bd_net [get_bd_pins $rst_gen/peripheral_aresetn] [get_bd_pins $hbm/APB_1_PRESET_N]
-    connect_bd_net [get_bd_pins ${hbm_clk_buf}/IBUF_OUT] [get_bd_pins $rst_gen/slowest_sync_clk]
-    connect_bd_net [get_bd_pins ${old_inst}/host_peripheral_areset] [get_bd_pins ${rst_gen}/ext_reset_in]
-
-    set rst_gen [tapasco::ip::create_rst_gen "mem_rst_gen"]
-
-    connect_bd_net [get_bd_pins $memory_clk_wiz/memory_clk] [get_bd_pins $rst_gen/slowest_sync_clk]
-    connect_bd_net [get_bd_pins $memory_clk_wiz/locked] [get_bd_pins $rst_gen/dcm_locked]
-    connect_bd_net [get_bd_pins $memory_clk_wiz/memory_clk] [get_bd_pins $hbm/AXI_23_ACLK]
-    connect_bd_net [get_bd_pins $rst_gen/peripheral_aresetn] [get_bd_pins $hbm/AXI_23_ARESET_N]
     connect_bd_net [get_bd_pins $memory_clk_wiz/clk_in1] [get_bd_pins $hbm_clk_buf/IBUF_OUT]
-    connect_bd_net [get_bd_pins ${old_inst}/host_peripheral_areset] [get_bd_pins ${rst_gen}/ext_reset_in]
 
-    set s_axi [create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 S_AXI]
-    connect_bd_intf_net [get_bd_intf_pins $hbm/SAXI_23] $s_axi
-    set ui_rst [create_bd_pin -dir O ui_clk_sync_rst]
-    connect_bd_net $ui_rst [get_bd_pins $rst_gen/peripheral_aresetn]
-    set lock [create_bd_pin -dir O mmcm_locked]
-    connect_bd_net $lock [get_bd_pins $memory_clk_wiz/locked]
-    set ui_clk [create_bd_pin -dir O ui_clk]
-    connect_bd_net $ui_clk [get_bd_pins $memory_clk_wiz/memory_clk]
+    set apb_rst_gen [tapasco::ip::create_rst_gen "apb_rst_gen"]
+    connect_bd_net [get_bd_pins ${hbm_clk_buf}/IBUF_OUT] [get_bd_pins $hbm/APB_0_PCLK]
+    connect_bd_net [get_bd_pins $apb_rst_gen/peripheral_aresetn] [get_bd_pins $hbm/APB_0_PRESET_N]
+    connect_bd_net [get_bd_pins ${hbm_clk_buf}/IBUF_OUT] [get_bd_pins $hbm/APB_1_PCLK]
+    connect_bd_net [get_bd_pins $apb_rst_gen/peripheral_aresetn] [get_bd_pins $hbm/APB_1_PRESET_N]
+    connect_bd_net [get_bd_pins ${hbm_clk_buf}/IBUF_OUT] [get_bd_pins $apb_rst_gen/slowest_sync_clk]
+    connect_bd_net $pcie_p_aresetn [get_bd_pins $apb_rst_gen/ext_reset_in]
 
+    set mem_rst_gen [tapasco::ip::create_rst_gen "mem_rst_gen"]
+    connect_bd_net [get_bd_pins $memory_clk_wiz/memory_clk] [get_bd_pins $mem_rst_gen/slowest_sync_clk]
+    connect_bd_net [get_bd_pins $memory_clk_wiz/locked] [get_bd_pins $mem_rst_gen/dcm_locked]
+    connect_bd_net $pcie_p_aresetn [get_bd_pins $mem_rst_gen/ext_reset_in]
+
+    set hbm_rst_gen [tapasco::ip::create_rst_gen "hbm_rst_gen"]
+    connect_bd_net [get_bd_pins $memory_clk_wiz/hbm_clk] [get_bd_pins $hbm_rst_gen/slowest_sync_clk]
+    connect_bd_net [get_bd_pins $memory_clk_wiz/locked] [get_bd_pins $hbm_rst_gen/dcm_locked]
+    connect_bd_net $pcie_p_aresetn [get_bd_pins $hbm_rst_gen/ext_reset_in]
+
+    set des_rst_gen [tapasco::ip::create_rst_gen "design_rst_gen"]
+    connect_bd_net [get_bd_pins $memory_clk_wiz/design_clk] [get_bd_pins $des_rst_gen/slowest_sync_clk]
+    connect_bd_net [get_bd_pins $memory_clk_wiz/locked] [get_bd_pins $des_rst_gen/dcm_locked]
+    connect_bd_net $pcie_p_aresetn [get_bd_pins $des_rst_gen/ext_reset_in]
+
+    # create Smartconnect between BlueDMA and HBM
+    set mig_ic [tapasco::ip::create_axi_sc "mig_ic" 1 1 2]
+    connect_bd_net [get_bd_pins $memory_clk_wiz/memory_clk] [get_bd_pins $mig_ic/aclk]
+    connect_bd_net [get_bd_pins $memory_clk_wiz/hbm_clk] [get_bd_pins $mig_ic/aclk1]
+
+    # connect HBM AXI clocks and resets
+    for {set i 0} {$i < 31} {incr i} {
+      if {$i < $num_masters || $i == 31} {
+        set port_no [format %02d $i]
+        connect_bd_net $design_aclk [get_bd_pins $hbm/AXI_${port_no}_ACLK]
+        connect_bd_net $design_p_aresetn [get_bd_pins $hbm/AXI_${port_no}_ARESET_N]
+      }
+    }
+    connect_bd_net [get_bd_pins $memory_clk_wiz/hbm_clk] [get_bd_pins $hbm/AXI_31_ACLK]
+    connect_bd_net [get_bd_pins $hbm_rst_gen/peripheral_aresetn] [get_bd_pins $hbm/AXI_31_ARESET_N]
+
+    # AXI connections
+    connect_bd_intf_net [get_bd_intf_pins $dma/M32_AXI] [get_bd_intf_pins $mig_ic/S00_AXI]
+    connect_bd_intf_net [get_bd_intf_pins $dma/M64_AXI] $m_axi_mem
+    connect_bd_intf_net [get_bd_intf_pins $mig_ic/M00_AXI] [get_bd_intf_pins $hbm/SAXI_31]
+    connect_bd_intf_net $s_axi_dma [get_bd_intf_pins $dma/S_AXI]
+
+    for {set i 0} {$i < $num_masters} {incr i} {
+      set port_no [format %02d $i]
+      connect_bd_intf_net [get_bd_intf_pins /memory/S_MEM_$i] [get_bd_intf_pins $hbm/SAXI_${port_no}]
+    }
+
+    # connect PCIe clock and reset
+    connect_bd_net $pcie_aclk [get_bd_pins $dma/m64_axi_aclk] [get_bd_pins $dma/s_axi_aclk]
+    connect_bd_net $pcie_p_aresetn [get_bd_pins $dma/m64_axi_aresetn] [get_bd_pins $dma/s_axi_aresetn]
+
+    # connect DDR clock and reset
+    set ddr_clk [get_bd_pins $memory_clk_wiz/memory_clk]
+    connect_bd_net [tapasco::subsystem::get_port "mem" "clk"] \
+      [get_bd_pins $dma/m32_axi_aclk]
+    connect_bd_net $ddr_p_aresetn \
+      [get_bd_pins $dma/m32_axi_aresetn]
+
+    # connect external DDR clk/rst output ports
+    connect_bd_net $ddr_clk $ddr_aclk
+    connect_bd_net $ddr_aresetn [get_bd_pins $mem_rst_gen/peripheral_aresetn]
+
+    # connect external design clk
+    connect_bd_net [get_bd_pins $memory_clk_wiz/design_clk] $design_clk
+    connect_bd_net [get_bd_pins $des_rst_gen/peripheral_aresetn] $design_aresetn
+
+    # set CATTRIP pin to zero
     set const [tapasco::ip::create_constant constz 1 0]
     make_bd_pins_external $const
 
+    # constraints
     set constraints_fn "$::env(TAPASCO_HOME_TCL)/platform/AU50/board.xdc"
     read_xdc $constraints_fn
     set_property PROCESSING_ORDER EARLY [get_files $constraints_fn]
 
     set debug_constr_fn "[get_property DIRECTORY [current_project]]/hbm_debug.xdc"
     set debug_constr_file [open $debug_constr_fn w+]
-    puts $debug_constr_file {connect_debug_port dbg_hub/clk [get_nets system_i/memory/mig/hbm_clk_buf/IBUF_OUT*]}
+    puts $debug_constr_file {connect_debug_port dbg_hub/clk [get_nets system_i/memory/hbm_clk_buf/IBUF_OUT*]}
     puts $debug_constr_file {set_property C_USER_SCAN_CHAIN 1 [get_debug_cores dbg_hub]}
     close $debug_constr_file
     read_xdc $debug_constr_fn
     set_property PROCESSING_ORDER NORMAL [get_files $debug_constr_fn]
-
-    current_bd_instance ${old_inst}
-
-    return $mig
   }
 
   proc create_pcie_core {} {

--- a/toolflow/vivado/platform/AU50/AU50.tcl
+++ b/toolflow/vivado/platform/AU50/AU50.tcl
@@ -1,0 +1,203 @@
+# Copyright (c) 2014-2023 Embedded Systems and Applications, TU Darmstadt.
+#
+# This file is part of TaPaSCo
+# (see https://github.com/esa-tu-darmstadt/tapasco).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+namespace eval platform {
+  set platform_dirname "AU50"
+  set pcie_width "x16"
+
+  if { [::tapasco::vivado_is_newer "2020.1"] == 0 } {
+    puts "Vivado [version -short] is too old to support AU50."
+    exit 1
+  }
+
+  source $::env(TAPASCO_HOME_TCL)/platform/pcie/pcie_base.tcl
+
+  proc get_ignored_segments { } {
+    set ignored [list]
+    set axi_index "23"
+    for {set j 0} {$j < 32} {incr j} {
+      set mem_index [format %02s $j]
+      lappend ignored "/memory/mig/mig_internal/SAXI_${axi_index}/HBM_MEM${mem_index}"
+    }
+    return $ignored
+  }
+
+  proc set_addressmap_AU50 {{args {}}} {
+    for {set i 0} {$i < 32} {incr i} {
+      assign_bd_address [get_bd_addr_segs memory/mig/mig_internal/SAXI_23/HBM_MEM[format %02s $i]]
+    }
+    return $args
+  }
+
+  proc create_mig_core {name} {
+    puts "Creating HBM controllers ..."
+
+    set old_inst [current_bd_instance .]
+    set mig [create_bd_cell -type hier ${name}]
+    current_bd_instance $mig
+
+    set hbm [tapasco::ip::create_hbm ${name}_internal]
+
+    set hbm_properties [list \
+      CONFIG.USER_APB_EN {false} \
+      CONFIG.USER_SWITCH_ENABLE_00 {true} \
+      CONFIG.USER_SWITCH_ENABLE_01 {true} \
+      CONFIG.USER_AXI_INPUT_CLK_FREQ [tapasco::get_mem_frequency] \
+      CONFIG.USER_XSDB_INTF_EN {TRUE} \
+      CONFIG.USER_HBM_DENSITY {8GB} \
+    ]
+
+    for {set i 0} {$i < 32} {incr i} {
+      set saxi [format %02s $i]
+      if {$i != 23} {
+        lappend hbm_properties CONFIG.USER_SAXI_${saxi} {false}
+      }
+    }
+
+    for {set i 0} {$i < 32} {incr i} {
+      if [expr {($i %2) == 0}] {
+        set mc [format %s [expr {$i / 2}]]
+        lappend hbm_properties CONFIG.USER_MC${mc}_ECC_BYPASS true
+        # lappend hbm_properties CONFIG.USER_MC${mc}_ECC_CORRECTION false
+        lappend hbm_properties CONFIG.USER_MC${mc}_EN_DATA_MASK true
+        lappend hbm_properties CONFIG.USER_MC${mc}_TRAFFIC_OPTION {Linear}
+        lappend hbm_properties CONFIG.USER_MC${mc}_BG_INTERLEAVE_EN true
+      }
+    }
+
+    set_property -dict $hbm_properties $hbm
+
+    set hbm_clk_buf [tapasco::ip::create_util_buf hbm_clk_buf]
+    apply_board_connection -board_interface "hbm_clk" -ip_intf "${hbm_clk_buf}/CLK_IN_D" -diagram "system"
+    connect_bd_net [get_bd_pins ${hbm_clk_buf}/IBUF_OUT] [get_bd_pins ${hbm}/HBM_REF_CLK_0]
+    connect_bd_net [get_bd_pins ${hbm_clk_buf}/IBUF_OUT] [get_bd_pins ${hbm}/HBM_REF_CLK_1]
+
+    set memory_clk_wiz [tapasco::ip::create_clk_wiz memory_clk_wiz]
+    set_property -dict [list CONFIG.CLK_OUT1_PORT {memory_clk} \
+      CONFIG.USE_SAFE_CLOCK_STARTUP {false} \
+      CONFIG.CLKOUT1_REQUESTED_OUT_FREQ [tapasco::get_mem_frequency] \
+      CONFIG.USE_LOCKED {true} \
+      CONFIG.USE_RESET {false}] $memory_clk_wiz
+
+    set rst_gen [tapasco::ip::create_rst_gen "apb_rst_gen"]
+    connect_bd_net [get_bd_pins ${hbm_clk_buf}/IBUF_OUT] [get_bd_pins $hbm/APB_0_PCLK]
+    connect_bd_net [get_bd_pins $rst_gen/peripheral_aresetn] [get_bd_pins $hbm/APB_0_PRESET_N]
+    connect_bd_net [get_bd_pins ${hbm_clk_buf}/IBUF_OUT] [get_bd_pins $hbm/APB_1_PCLK]
+    connect_bd_net [get_bd_pins $rst_gen/peripheral_aresetn] [get_bd_pins $hbm/APB_1_PRESET_N]
+    connect_bd_net [get_bd_pins ${hbm_clk_buf}/IBUF_OUT] [get_bd_pins $rst_gen/slowest_sync_clk]
+    connect_bd_net [get_bd_pins ${old_inst}/host_peripheral_areset] [get_bd_pins ${rst_gen}/ext_reset_in]
+
+    set rst_gen [tapasco::ip::create_rst_gen "mem_rst_gen"]
+
+    connect_bd_net [get_bd_pins $memory_clk_wiz/memory_clk] [get_bd_pins $rst_gen/slowest_sync_clk]
+    connect_bd_net [get_bd_pins $memory_clk_wiz/locked] [get_bd_pins $rst_gen/dcm_locked]
+    connect_bd_net [get_bd_pins $memory_clk_wiz/memory_clk] [get_bd_pins $hbm/AXI_23_ACLK]
+    connect_bd_net [get_bd_pins $rst_gen/peripheral_aresetn] [get_bd_pins $hbm/AXI_23_ARESET_N]
+    connect_bd_net [get_bd_pins $memory_clk_wiz/clk_in1] [get_bd_pins $hbm_clk_buf/IBUF_OUT]
+    connect_bd_net [get_bd_pins ${old_inst}/host_peripheral_areset] [get_bd_pins ${rst_gen}/ext_reset_in]
+
+    set s_axi [create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 S_AXI]
+    connect_bd_intf_net [get_bd_intf_pins $hbm/SAXI_23] $s_axi
+    set ui_rst [create_bd_pin -dir O ui_clk_sync_rst]
+    connect_bd_net $ui_rst [get_bd_pins $rst_gen/peripheral_aresetn]
+    set lock [create_bd_pin -dir O mmcm_locked]
+    connect_bd_net $lock [get_bd_pins $memory_clk_wiz/locked]
+    set ui_clk [create_bd_pin -dir O ui_clk]
+    connect_bd_net $ui_clk [get_bd_pins $memory_clk_wiz/memory_clk]
+
+    set const [tapasco::ip::create_constant constz 1 0]
+    make_bd_pins_external $const
+
+    set constraints_fn "$::env(TAPASCO_HOME_TCL)/platform/AU50/board.xdc"
+    read_xdc $constraints_fn
+    set_property PROCESSING_ORDER EARLY [get_files $constraints_fn]
+
+    set debug_constr_fn "[get_property DIRECTORY [current_project]]/hbm_debug.xdc"
+    set debug_constr_file [open $debug_constr_fn w+]
+    puts $debug_constr_file {connect_debug_port dbg_hub/clk [get_nets system_i/memory/mig/hbm_clk_buf/IBUF_OUT*]}
+    puts $debug_constr_file {set_property C_USER_SCAN_CHAIN 1 [get_debug_cores dbg_hub]}
+    close $debug_constr_file
+    read_xdc $debug_constr_fn
+    set_property PROCESSING_ORDER NORMAL [get_files $debug_constr_fn]
+
+    current_bd_instance ${old_inst}
+
+    return $mig
+  }
+
+  proc create_pcie_core {} {
+    puts "Creating AXI PCIe Gen3 bridge ..."
+
+    set pcie_core [tapasco::ip::create_axi_pcie3_0_usp axi_pcie3_0]
+
+    apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {pci_express_x16 ( PCI Express ) } Manual_Source {Auto}}  [get_bd_intf_pins $pcie_core/pcie_mgt]
+    apply_bd_automation -rule xilinx.com:bd_rule:board -config { Board_Interface {pcie_perstn ( PCI Express ) } Manual_Source {New External Port (ACTIVE_LOW)}}  [get_bd_pins $pcie_core/sys_rst_n]
+
+    apply_bd_automation -rule xilinx.com:bd_rule:xdma -config { accel {1} auto_level {IP Level} axi_clk {Maximum Data Width} axi_intf {AXI Memory Mapped} bar_size {Disable} bypass_size {Disable} c2h {4} cache_size {32k} h2c {4} lane_width {X16} link_speed {8.0 GT/s (PCIe Gen 3)}}  [get_bd_cells $pcie_core]
+
+    set pcie_properties [list \
+      CONFIG.functional_mode {AXI_Bridge} \
+      CONFIG.mode_selection {Advanced} \
+      CONFIG.pl_link_cap_max_link_width {X16} \
+      CONFIG.pl_link_cap_max_link_speed {8.0_GT/s} \
+      CONFIG.axi_addr_width {64} \
+      CONFIG.pipe_sim {true} \
+      CONFIG.pf0_revision_id {01} \
+      CONFIG.pf0_base_class_menu {Memory_controller} \
+      CONFIG.pf0_sub_class_interface_menu {Other_memory_controller} \
+      CONFIG.pf0_interrupt_pin {NONE} \
+      CONFIG.pf0_msi_enabled {false} \
+      CONFIG.SYS_RST_N_BOARD_INTERFACE {pcie_perstn} \
+      CONFIG.PCIE_BOARD_INTERFACE {pci_express_x16} \
+      CONFIG.pf0_msix_enabled {true} \
+      CONFIG.c_m_axi_num_write {32} \
+      CONFIG.pf0_msix_impl_locn {External} \
+      CONFIG.pf0_bar0_size {64} \
+      CONFIG.pf0_bar0_scale {Megabytes} \
+      CONFIG.pf0_bar0_64bit {true} \
+      CONFIG.axi_data_width {512_bit} \
+      CONFIG.pf0_device_id {7038} \
+      CONFIG.pf0_class_code_base {05} \
+      CONFIG.pf0_class_code_sub {80} \
+      CONFIG.pf0_class_code_interface {00} \
+      CONFIG.xdma_axilite_slave {true} \
+      CONFIG.coreclk_freq {500} \
+      CONFIG.plltype {QPLL1} \
+      CONFIG.pf0_msix_cap_table_size {83} \
+      CONFIG.pf0_msix_cap_table_offset {20000} \
+      CONFIG.pf0_msix_cap_table_bir {BAR_1:0} \
+      CONFIG.pf0_msix_cap_pba_offset {28000} \
+      CONFIG.pf0_msix_cap_pba_bir {BAR_1:0} \
+      CONFIG.bar_indicator {BAR_1:0} \
+      CONFIG.bar0_indicator {0}
+    ]
+
+    if {[catch {set_property -dict $pcie_properties $pcie_core}]} {
+      error "ERROR: Failed to configure PCIe bridge. This may be related to the format settings of your OS for numbers. Please check that it is set to 'United States' (see AR# 51331)"
+    }
+    set_property -dict $pcie_properties $pcie_core
+
+    tapasco::ip::create_msixusptrans "MSIxTranslator" $pcie_core
+
+    return $pcie_core
+  }
+
+  tapasco::register_plugin "platform::set_addressmap_AU50" "post-address-map"
+
+}

--- a/toolflow/vivado/platform/AU50/AU50.tcl
+++ b/toolflow/vivado/platform/AU50/AU50.tcl
@@ -165,7 +165,9 @@ namespace eval platform {
       CONFIG.CLKOUT3_REQUESTED_OUT_FREQ {450.000} \
       CONFIG.USE_SAFE_CLOCK_STARTUP {false} \
       CONFIG.USE_LOCKED {true} \
-      CONFIG.USE_RESET {false}] $memory_clk_wiz
+      CONFIG.USE_RESET {false} \
+      CONFIG.OPTIMIZE_CLOCKING_STRUCTURE_EN {true} \
+    ] $memory_clk_wiz
     connect_bd_net [get_bd_pins $memory_clk_wiz/clk_in1] [get_bd_pins $hbm_clk_buf/IBUF_OUT]
 
     set apb_rst_gen [tapasco::ip::create_rst_gen "apb_rst_gen"]

--- a/toolflow/vivado/platform/AU50/board.xdc
+++ b/toolflow/vivado/platform/AU50/board.xdc
@@ -1,0 +1,21 @@
+# Copyright (c) 2014-2023 Embedded Systems and Applications, TU Darmstadt.
+#
+# This file is part of TaPaSCo
+# (see https://github.com/esa-tu-darmstadt/tapasco).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+set_property PACKAGE_PIN J18 [get_ports {dout_0[0]}]
+set_property IOSTANDARD LVCMOS18 [get_ports {dout_0[0]}]

--- a/toolflow/vivado/platform/AU50/platform.json
+++ b/toolflow/vivado/platform/AU50/platform.json
@@ -1,0 +1,12 @@
+{
+	"Name" : "AU50",
+	"Description" : "Alveo U50 Data Center Accelerator Card",
+	"TclLibrary" : "AU50.tcl",
+	"Part" : "xcu50-fsvh2104-2-e",
+	"BoardPart" : "xilinx.com:au50:part0:1.3",
+	"BoardPreset" : "AU50",
+	"TargetUtilization" : 90,
+	"Benchmark" : "AU50.benchmark",
+	"HostFrequency": 250.0,
+	"MemFrequency": 300.0
+}

--- a/toolflow/vivado/platform/AU50/plugins/sfpplus.tcl
+++ b/toolflow/vivado/platform/AU50/plugins/sfpplus.tcl
@@ -24,15 +24,17 @@ namespace eval sfpplus {
   }
 
   proc get_available_modes {} {
-    return {"10G"}
+    return {"10G" "100G"}
   }
 
   proc num_available_ports {mode} {
     variable available_ports
     if {$mode == "10G"} {
       return [10g::num_available_ports]
+    } elseif {$mode == "100G"} {
+      return [100g::num_available_ports]
     } else {
-      puts "Invalid SFP+ mode: mode $mode is not supported by this platform. Available modes are: 10G"
+      puts "Invalid SFP+ mode: mode $mode is not supported by this platform. Available modes are: 10G, 100G"
       exit
     }    
   }
@@ -40,8 +42,10 @@ namespace eval sfpplus {
   proc generate_cores {mode ports} {
     if {$mode == "10G"} {
       return [10g::generate_cores $ports]
+    } elseif {$mode == "100G"} {
+      return [100g::generate_cores $ports]
     } else {
-      puts "Invalid SFP+ mode: mode $mode is not supported by this platform. Available modes are: 10G"
+      puts "Invalid SFP+ mode: mode $mode is not supported by this platform. Available modes are: 10G, 100G"
       exit
     }
   }

--- a/toolflow/vivado/platform/AU50/plugins/sfpplus.tcl
+++ b/toolflow/vivado/platform/AU50/plugins/sfpplus.tcl
@@ -1,0 +1,56 @@
+# Copyright (c) 2014-2023 Embedded Systems and Applications, TU Darmstadt.
+#
+# This file is part of TaPaSCo
+# (see https://github.com/esa-tu-darmstadt/tapasco).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+namespace eval sfpplus {
+
+  proc is_sfpplus_supported {} {
+    return true
+  }
+
+  proc get_available_modes {} {
+    return {"10G"}
+  }
+
+  proc num_available_ports {mode} {
+    variable available_ports
+    if {$mode == "10G"} {
+      return [10g::num_available_ports]
+    } else {
+      puts "Invalid SFP+ mode: mode $mode is not supported by this platform. Available modes are: 10G"
+      exit
+    }    
+  }
+
+  proc generate_cores {mode ports} {
+    if {$mode == "10G"} {
+      return [10g::generate_cores $ports]
+    } else {
+      puts "Invalid SFP+ mode: mode $mode is not supported by this platform. Available modes are: 10G"
+      exit
+    }
+  }
+
+  proc addressmap {{args {}}} {
+    set args [lappend args "M_NETWORK" [list 0x2500000 0 0 ""]]
+    return $args
+  }
+
+  tapasco::register_plugin "platform::sfpplus::addressmap" "post-address-map"
+
+}

--- a/toolflow/vivado/platform/AU50/plugins/sfpplus_100g.tcl
+++ b/toolflow/vivado/platform/AU50/plugins/sfpplus_100g.tcl
@@ -1,0 +1,150 @@
+# Copyright (c) 2014-2020 Embedded Systems and Applications, TU Darmstadt.
+#
+# This file is part of TaPaSCo
+# (see https://github.com/esa-tu-darmstadt/tapasco).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+namespace eval sfpplus {
+
+  namespace eval 100g {
+
+    variable available_ports 1
+    variable cmac_cores            {"CMACE4_X0Y3"}
+    variable gt_groups             {"X0Y28~X0Y31"}
+    variable refclk_pins           {"N36"}
+
+    proc num_available_ports {} {
+      variable available_ports
+      return $available_ports
+    }
+
+    proc generate_cores {ports} {
+
+      set num_streams [dict size $ports]
+
+      puts "Generating $num_streams SFPPLUS cores"
+      set constraints_fn "[get_property DIRECTORY [current_project]]/sfpplus.xdc"
+      set constraints_file [open $constraints_fn w+]
+
+      # QSFP Ports
+      set const_one [tapasco::ip::create_constant const_one 1 1]
+
+      # Clocking wizard for creating clock dclk; Used for dclk and AXI-Lite clocks of core
+      set dclk_wiz [tapasco::ip::create_clk_wiz dclk_wiz]
+      set_property -dict [list \
+        CONFIG.USE_SAFE_CLOCK_STARTUP {true} \
+        CONFIG.CLKOUT1_REQUESTED_OUT_FREQ 100 \
+        CONFIG.USE_LOCKED {false} \
+        CONFIG.USE_RESET {false} \
+      ] $dclk_wiz
+
+      # Reset Generator for dclk reset
+      set dclk_reset [tapasco::ip::create_rst_gen dclk_reset]
+
+      connect_bd_net [get_bd_pins $dclk_wiz/clk_out1] [get_bd_pins $dclk_reset/slowest_sync_clk]
+      connect_bd_net [get_bd_pins design_peripheral_aresetn] [get_bd_pins $dclk_reset/ext_reset_in]
+      connect_bd_net [get_bd_pins design_clk] [get_bd_pins $dclk_wiz/clk_in1]
+
+      set first_port 0
+      foreach port [dict keys $ports] {
+        set name [dict get $ports $port]
+        generate_core $port $name $first_port $constraints_file
+        incr first_port 1
+      }
+
+      close $constraints_file
+      read_xdc $constraints_fn
+      set_property PROCESSING_ORDER NORMAL [get_files $constraints_fn]
+    }
+
+    # Generate a SFP+-Core to handle the ports of one physical cage
+    # @param physical_port the number of the physical cage
+    # @param name name of the port
+    # @param first_port the first free master on the AXI-Lite Config interconnect
+    # @param constraints_file the file used for constraints
+    proc generate_core {physical_port name first_port constraints_file} {
+      variable refclk_pins
+      variable cmac_cores
+      variable gt_groups
+
+      # Create and configure core
+      set core [tapasco::ip::create_100g_ethernet ethernet_$physical_port]
+
+      # Create and constrain refclk pin
+      set gt_refclk [create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 qsfp${physical_port}_161mhz]
+      set_property CONFIG.FREQ_HZ 161132812 $gt_refclk
+      puts $constraints_file [format {set_property PACKAGE_PIN %s [get_ports %s]} [lindex $refclk_pins $physical_port] qsfp${physical_port}_161mhz_clk_p]
+
+      set_property -dict [list \
+        CONFIG.CMAC_CAUI4_MODE {1} \
+        CONFIG.NUM_LANES {4x25} \
+        CONFIG.USER_INTERFACE {AXIS} \
+        CONFIG.GT_REF_CLK_FREQ {161.1328125} \
+        CONFIG.TX_FLOW_CONTROL {0} \
+        CONFIG.RX_FLOW_CONTROL {0} \
+        CONFIG.INCLUDE_RS_FEC {1} \
+        CONFIG.ENABLE_AXI_INTERFACE {0} \
+        CONFIG.INCLUDE_STATISTICS_COUNTERS {0} \
+        CONFIG.RX_MAX_PACKET_LEN {16383} \
+        CONFIG.CMAC_CORE_SELECT [lindex $cmac_cores $physical_port] \
+        CONFIG.GT_GROUP_SELECT [lindex $gt_groups $physical_port] \
+      ] $core
+
+      # Connect core
+      connect_bd_net [get_bd_pins $core/sys_reset] [get_bd_pins dclk_reset/peripheral_reset]
+      connect_bd_net [get_bd_pins $core/drp_clk] [get_bd_pins dclk_wiz/clk_out1]
+      connect_bd_net [get_bd_pins $core/init_clk] [get_bd_pins dclk_wiz/clk_out1]
+
+      connect_bd_intf_net $gt_refclk [get_bd_intf_pins $core/gt_ref_clk]
+      make_bd_intf_pins_external [get_bd_intf_pins $core/gt_serial_port]
+
+      connect_bd_intf_net [get_bd_intf_pins $core/axis_rx] [get_bd_intf_pins AXIS_RX_${name}]
+      connect_bd_intf_net [get_bd_intf_pins $core/axis_tx] [get_bd_intf_pins AXIS_TX_${name}]
+      connect_bd_net [get_bd_pins $core/gt_txusrclk2] [get_bd_pins $core/rx_clk]
+
+      # clock and resets to AXIS interconnect
+      connect_bd_net [get_bd_pins $core/gt_txusrclk2] [get_bd_pins /Network/sfp_tx_clock_${name}]
+      connect_bd_net [get_bd_pins $core/gt_txusrclk2] [get_bd_pins /Network/sfp_rx_clock_${name}]
+
+      set out_inv [create_inverter tx_reset_inverter_${name}]
+      connect_bd_net [get_bd_pins $core/usr_tx_reset] [get_bd_pins $out_inv/Op1]
+      connect_bd_net [get_bd_pins /Network/sfp_tx_resetn_${name}] [get_bd_pins $out_inv/Res]
+
+      set out_inv [create_inverter rx_reset_inverter_${name}]
+      connect_bd_net [get_bd_pins $core/usr_rx_reset] [get_bd_pins $out_inv/Op1]
+      connect_bd_net [get_bd_pins /Network/sfp_rx_resetn_${name}] [get_bd_pins $out_inv/Res]
+
+      connect_bd_net [get_bd_pins const_one/dout] [get_bd_pins $core/ctl_rx_enable]
+      connect_bd_net [get_bd_pins $core/stat_rx_aligned] [get_bd_pins $core/ctl_tx_enable]
+
+      connect_bd_net [get_bd_pins const_one/dout] [get_bd_pins $core/ctl_rx_rsfec_enable]
+      connect_bd_net [get_bd_pins const_one/dout] [get_bd_pins $core/ctl_rx_rsfec_enable_correction]
+      connect_bd_net [get_bd_pins const_one/dout] [get_bd_pins $core/ctl_rx_rsfec_enable_indication]
+      connect_bd_net [get_bd_pins const_one/dout] [get_bd_pins $core/ctl_tx_rsfec_enable]
+
+      set aligned_inverter [tapasco::ip::create_logic_vector aligned_inverter_$physical_port]
+      set_property -dict [list CONFIG.C_SIZE {1} CONFIG.C_OPERATION {not} CONFIG.LOGO_FILE {data/sym_notgate.png}] $aligned_inverter
+      connect_bd_net [get_bd_pins $core/stat_rx_aligned] [get_bd_pins $aligned_inverter/Op1]
+      connect_bd_net [get_bd_pins $aligned_inverter/Res] [get_bd_pins $core/ctl_tx_send_rfi]
+    }
+
+    proc create_inverter {name} {
+      variable ret [tapasco::ip::create_logic_vector $name]
+      set_property -dict [list CONFIG.C_SIZE {1} CONFIG.C_OPERATION {not} CONFIG.LOGO_FILE {data/sym_notgate.png}] [get_bd_cells $name]
+      return $ret
+    }
+  }
+}

--- a/toolflow/vivado/platform/AU50/plugins/sfpplus_10g.tcl
+++ b/toolflow/vivado/platform/AU50/plugins/sfpplus_10g.tcl
@@ -1,0 +1,191 @@
+# Copyright (c) 2014-2023 Embedded Systems and Applications, TU Darmstadt.
+#
+# This file is part of TaPaSCo
+# (see https://github.com/esa-tu-darmstadt/tapasco).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+namespace eval sfpplus {
+
+  namespace eval 10g {
+
+    variable available_ports 4
+    variable refclk_pins           {"N36"}
+    variable gt_quads              {"Quad_X0Y7"}
+    variable gt_lanes              {"X0Y28" "X0Y29" "X0Y30" "X0Y31"}
+
+    proc num_available_ports {} {
+      variable available_ports
+      return $available_ports
+    }
+
+    proc generate_cores {ports} {
+      set num_streams [dict size $ports]
+
+      create_network_config_master
+
+      puts "Generating $num_streams SFPPLUS cores"
+      set constraints_fn "[get_property DIRECTORY [current_project]]/sfpplus.xdc"
+      set constraints_file [open $constraints_fn w+]
+
+      # AXI Interconnect for Configuration
+      set axi_config [tapasco::ip::create_axi_ic axi_config 1 $num_streams]
+
+      # Clocking wizard for creating clock dclk; Used for dclk and AXI-Lite clocks of core
+      set dclk_wiz [tapasco::ip::create_clk_wiz dclk_wiz]
+      set_property -dict [list CONFIG.USE_SAFE_CLOCK_STARTUP {true} CONFIG.CLKOUT1_REQUESTED_OUT_FREQ 100 CONFIG.USE_LOCKED {false} CONFIG.USE_RESET {false}] $dclk_wiz
+
+      # Reset Generator for dclk reset
+      set dclk_reset [tapasco::ip::create_rst_gen dclk_reset]
+
+      connect_bd_net [get_bd_pins $dclk_wiz/clk_out1] [get_bd_pins $dclk_reset/slowest_sync_clk]
+      connect_bd_net [get_bd_pins design_peripheral_aresetn] [get_bd_pins $dclk_reset/ext_reset_in]
+      connect_bd_net [get_bd_pins design_clk] [get_bd_pins $dclk_wiz/clk_in1]
+      connect_bd_net [get_bd_pins $axi_config/M*_ACLK] [get_bd_pins $dclk_wiz/clk_out1]
+      connect_bd_net [get_bd_pins $axi_config/M*_ARESETN] [get_bd_pins $dclk_reset/peripheral_aresetn]
+
+      connect_bd_intf_net [get_bd_intf_pins $axi_config/S00_AXI] [get_bd_intf_pins S_NETWORK]
+      connect_bd_net [get_bd_pins $axi_config/S00_ACLK] [get_bd_pins design_clk]
+      connect_bd_net [get_bd_pins $axi_config/S00_ARESETN] [get_bd_pins design_interconnect_aresetn]
+      connect_bd_net [get_bd_pins $axi_config/ACLK] [get_bd_pins design_clk]
+      connect_bd_net [get_bd_pins $axi_config/ARESETN] [get_bd_pins design_interconnect_aresetn]
+
+      # Cores need constant clock select input
+      set const_clksel [tapasco::ip::create_constant const_clksel 3 5]
+
+      # Generate SFP+-Cores
+      # Each core can handle (up to) all four ports of one physical cage
+      set first_port 0
+      for {set i 0} {$i < 2} {incr i} {
+        set ports_created [generate_core $i $ports $first_port $constraints_file]
+        incr first_port $ports_created
+      }
+
+      close $constraints_file
+      read_xdc $constraints_fn
+      set_property PROCESSING_ORDER NORMAL [get_files $constraints_fn]
+    }
+
+    # Generate a SFP+-Core to handle the ports of one physical cage
+    # @param number the number of the physical cage
+    # @param physical_ports the numbers of all physical_ports which are required in the design
+    # @param first_port the first free master on the AXI-Lite Config interconnect
+    # @param constraints_file git stthe file used for constraints
+    # @return the number of ports created with this core
+    proc generate_core {number physical_ports first_port constraints_file} {
+      variable refclk_pins
+      variable gt_quads
+      variable gt_lanes
+
+      # Select physical_ports which will be handled by this core
+      set ports [list]
+
+      for {set i 0} {$i < 4} {incr i} {
+        set port_number [expr ($number * 4) + $i]
+        if {[dict exists $physical_ports $port_number]} {
+          lappend ports $port_number
+        }
+      }
+
+      set num_ports [llength $ports]
+
+      # No ports for this core found -> abort
+      if {$num_ports == 0} {
+        return 0
+      }
+
+      # Create and constrain refclk pin
+      set gt_refclk [create_bd_intf_port -mode Slave -vlnv xilinx.com:interface:diff_clock_rtl:1.0 gt_refclk_$number]
+      set_property CONFIG.FREQ_HZ 161132812 $gt_refclk
+      puts $constraints_file [format {set_property PACKAGE_PIN %s [get_ports %s]} [lindex $refclk_pins $number] gt_refclk_${number}_clk_p]
+
+
+      # Create and configure core
+      set core [tapasco::ip::create_xxv_ethernet ethernet_$number]
+
+      set_property -dict [list \
+        CONFIG.NUM_OF_CORES $num_ports \
+        CONFIG.LINE_RATE {10} \
+        CONFIG.BASE_R_KR {BASE-R} \
+        CONFIG.INCLUDE_AXI4_INTERFACE {1} \
+        CONFIG.INCLUDE_STATISTICS_COUNTERS {0} \
+        CONFIG.GT_REF_CLK_FREQ {161.1328125} \
+        CONFIG.GT_GROUP_SELECT [lindex $gt_quads $number]
+      ] $core
+
+      # Configure GT lanes based on required ports
+      set lanes [list]
+      for {set i 0} {$i < $num_ports} {incr i} {
+        set lane_index [format %01s [expr $i + 1]]
+        set gt_lane [lindex $gt_lanes [lindex $ports $i]]
+        lappend lanes CONFIG.LANE${lane_index}_GT_LOC $gt_lane
+      }
+      set_property -dict $lanes $core
+
+      connect_bd_intf_net $gt_refclk [get_bd_intf_pins $core/gt_ref_clk]
+      connect_bd_net [get_bd_pins $core/sys_reset] [get_bd_pins dclk_reset/peripheral_reset]
+      make_bd_intf_pins_external [get_bd_intf_pins $core/gt_serial_port]
+      connect_bd_net [get_bd_pins $core/dclk] [get_bd_pins dclk_wiz/clk_out1]
+
+      set addr 0x2500000
+
+      # Connect core
+      for {set i 0} {$i < $num_ports} {incr i} {
+        set name [dict get $physical_ports [lindex $ports $i]]
+
+        # Register SFP connections as platform components for use in runtime
+        ::platform::addressmap::add_platform_component [format "PLATFORM_COMPONENT_SFP_NETWORK_CONTROLLER_%d" $i] $addr 0x10000
+        incr addr 0x10000
+
+        connect_bd_intf_net [get_bd_intf_pins $core/axis_rx_${i}] [get_bd_intf_pins AXIS_RX_${name}]
+        connect_bd_intf_net [get_bd_intf_pins $core/axis_tx_${i}] [get_bd_intf_pins AXIS_TX_${name}]
+        connect_bd_intf_net [get_bd_intf_pins $core/s_axi_${i}] [get_bd_intf_pins /Network/AXI_Config/M[format %02d [expr $first_port + $i]]_AXI]
+        connect_bd_net [get_bd_pins $core/s_axi_aclk_${i}] [get_bd_pins dclk_wiz/clk_out1]
+        connect_bd_net [get_bd_pins $core/s_axi_aresetn_${i}] [get_bd_pins dclk_reset/peripheral_aresetn]
+        connect_bd_net [get_bd_pins $core/tx_clk_out_${i}] [get_bd_pins $core/rx_core_clk_${i}]
+        connect_bd_net [get_bd_pins $core/txoutclksel_in_${i}] [get_bd_pins const_clksel/dout]
+        connect_bd_net [get_bd_pins $core/rxoutclksel_in_${i}] [get_bd_pins const_clksel/dout]
+
+        connect_bd_net [get_bd_pins $core/tx_clk_out_${i}] [get_bd_pins /Network/sfp_tx_clock_${name}]
+        connect_bd_net [get_bd_pins $core/tx_clk_out_${i}] [get_bd_pins /Network/sfp_rx_clock_${name}]
+
+        set out_inv [create_inverter tx_reset_inverter_${name}]
+        connect_bd_net [get_bd_pins $core/user_tx_reset_${i}] [get_bd_pins $out_inv/Op1]
+        connect_bd_net [get_bd_pins /Network/sfp_tx_resetn_${name}] [get_bd_pins $out_inv/Res]
+
+        set out_inv [create_inverter rx_reset_inverter_${name}]
+        connect_bd_net [get_bd_pins $core/user_rx_reset_${i}] [get_bd_pins $out_inv/Op1]
+        connect_bd_net [get_bd_pins /Network/sfp_rx_resetn_${name}] [get_bd_pins $out_inv/Res]
+      }
+      return $num_ports
+    }
+
+    proc create_inverter {name} {
+      variable ret [create_bd_cell -type ip -vlnv xilinx.com:ip:util_vector_logic:2.0 $name]
+      set_property -dict [list CONFIG.C_SIZE {1} CONFIG.C_OPERATION {not} CONFIG.LOGO_FILE {data/sym_notgate.png}] [get_bd_cells $name]
+      return $ret
+    }
+
+    # Create AXI connection to Host interconnect for network configuration interfaces
+    proc create_network_config_master {} {
+      create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 S_NETWORK
+      set m_si [create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:aximm_rtl:1.0 /host/M_NETWORK]
+      set num_mi_old [get_property CONFIG.NUM_MI [get_bd_cells /host/out_ic]]
+      set num_mi [expr "$num_mi_old + 1"]
+      set_property -dict [list CONFIG.NUM_MI $num_mi] [get_bd_cells /host/out_ic]
+      connect_bd_intf_net $m_si [get_bd_intf_pins /host/out_ic/[format "M%02d_AXI" $num_mi_old]]
+    }
+  }
+}

--- a/toolflow/vivado/platform/AU50/plugins/svm.tcl
+++ b/toolflow/vivado/platform/AU50/plugins/svm.tcl
@@ -17,12 +17,130 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
+# If SVM is in use we only use two HBM port (DMA and MMU)
+if {[tapasco::is_feature_enabled "SVM"]} {
+  proc get_ignored_segments {} {
+    set ignored [list]
+    for {set i 0} {$i < 32} {incr i} {
+      set mem_index [format %02s $i]
+      lappend ignored "/memory/hbm_0/SAXI_00/HBM_MEM${mem_index}"
+      lappend ignored "/memory/hbm_0/SAXI_31/HBM_MEM${mem_index}"
+    }
+    return $ignored
+  }
+
+  proc set_addressmap_AU50 {{args {}}} {
+    set num_masters [llength [::arch::get_masters]]
+    for {set i 0} {$i < 32} {incr i} {
+      set mem_index [format %02s $i]
+      assign_bd_address [get_bd_addr_segs memory/hbm_0/SAXI_00/HBM_MEM${mem_index}]
+      assign_bd_address [get_bd_addr_segs memory/hbm_0/SAXI_31/HBM_MEM${mem_index}]
+    }
+    for {set i 1} {$i < $num_masters} {incr i} {
+      set name "M_MEM_$i"
+      set args [lappend args $name [list 0 0 0 ""]]
+    }
+    return $args
+  }
+}
+
 namespace eval svm {
   proc is_svm_supported {} {
     return true
   }
 
+  # TODO implement network migrations
   proc is_network_port_valid {port_no} {
     return false
+  }
+
+  proc add_iommu {args} {
+    if {[tapasco::is_feature_enabled "SVM"]} {
+      set old_instance [current_bd_instance .]
+
+      # add slave port to host subsystem
+      current_bd_instance "/host"
+      set m_mmu [create_bd_intf_pin -mode Master -vlnv xilinx.com:interface:aximm_rtl:1.0 "M_MMU"]
+      set num_mi_out_old [get_property CONFIG.NUM_MI [get_bd_cells out_ic]]
+      set num_mi_out [expr "$num_mi_out_old + 1"]
+      set_property -dict [list CONFIG.NUM_MI $num_mi_out] [get_bd_cells out_ic]
+      connect_bd_intf_net [get_bd_intf_pins out_ic/[format "M%02d_AXI" $num_mi_out_old]] $m_mmu
+
+      # remove BlueDMA and insert PageDMA core
+      current_bd_instance "/memory"
+
+      set pcie_aclk [tapasco::subsystem::get_port "host" "clk"]
+      set pcie_p_aresetn [tapasco::subsystem::get_port "host" "rst" "peripheral" "resetn"]
+      set design_aclk [tapasco::subsystem::get_port "design" "clk"]
+      set memory_aclk [tapasco::subsystem::get_port "mem" "clk"]
+      set hbm_clk [get_bd_pins memory_clk_wiz/hbm_clk]
+      set hbm_aresetn [get_bd_pins hbm_rst_gen/peripheral_aresetn]
+      set mig_ic [get_bd_cells mig_ic]
+      set hbm [get_bd_cells hbm_0]
+
+      delete_bd_objs [get_bd_nets dma_IRQ_write] [get_bd_nets dma_IRQ_read] [get_bd_intf_nets S_DMA_1] [get_bd_intf_nets dma_m32_axi] [get_bd_intf_nets dma_m64_axi] [get_bd_cells dma]
+      disconnect_bd_net /memory/memory_clk_wiz_memory_clk [get_bd_pins $mig_ic/aclk]
+      disconnect_bd_net /memory/design_clk_1 [get_bd_pins hbm_0/AXI_00_ACLK]
+      disconnect_bd_net /memory/design_peripheral_aresetn_1 [get_bd_pins hbm_0/AXI_00_ARESET_N]
+
+      # TODO insert NetworkPageDMA if necessary
+      set page_dma [tapasco::ip::create_page_dma dma_0]
+      connect_bd_net $pcie_aclk [get_bd_pins $page_dma/aclk]
+      connect_bd_net $pcie_p_aresetn [get_bd_pins $page_dma/resetn]
+      connect_bd_net [get_bd_pins $page_dma/intr_c2h] [get_bd_pins intr_PLATFORM_COMPONENT_DMA0_READ]
+      connect_bd_net [get_bd_pins $page_dma/intr_h2c] [get_bd_pins intr_PLATFORM_COMPONENT_DMA0_WRITE]
+      connect_bd_intf_net [get_bd_intf_pins S_DMA] [get_bd_intf_pins $page_dma/S_AXI_CTRL]
+      connect_bd_intf_net [get_bd_intf_pins $page_dma/M_AXI_MEM] [get_bd_intf_pins $mig_ic/S00_AXI]
+      connect_bd_intf_net [get_bd_intf_pins $page_dma/M_AXI_PCI] [get_bd_intf_pins M_HOST]
+
+save_bd_design
+
+      # create smartconnect tree in case of multiple master ports
+      set num_masters [llength [::arch::get_masters]]
+      for {set i 0} {$i < $num_masters} {incr i} {
+        delete_bd_objs [get_bd_intf_nets "S_MEM_${i}_1"]
+      }
+      set sc_tree [tapasco::create_smartconnect_tree "mmu_sc_tree" $num_masters]
+
+
+      # disable unused HBM ports
+      if {$num_masters > 1} {
+        set hbm_config [list]
+        for {set i 1} {$i < $num_masters && $i < 31} {incr i} {
+          lappend hbm_config CONFIG.USER_SAXI_[format %02s $i] {false}
+        }
+        set_property -dict $hbm_config $hbm
+      }
+
+      # add MMU to memory subsystem
+      set s_mmu [create_bd_intf_pin -mode Slave -vlnv xilinx.com:interface:aximm_rtl:1.0 "S_MMU"]
+      set mmu [tapasco::ip::create_tapasco_mmu mmu_0]
+      set mmu_mem_sc [tapasco::ip::create_axi_sc "mmu_mem_sc" 1 1 2]
+
+      connect_bd_net $pcie_aclk [get_bd_pins $mmu/aclk]
+      connect_bd_net $pcie_p_aresetn [get_bd_pins $mmu/resetn]
+      connect_bd_net $pcie_aclk [get_bd_pins $sc_tree/m_aclk]
+      connect_bd_net $design_aclk [get_bd_pins $sc_tree/s_aclk]
+      connect_bd_net $pcie_aclk [get_bd_pins $mmu_mem_sc/aclk]
+      connect_bd_net $hbm_clk [get_bd_pins $mmu_mem_sc/aclk1]
+      connect_bd_net $pcie_aclk [get_bd_pins $mig_ic/aclk]
+      connect_bd_net $hbm_clk [get_bd_pins $hbm/AXI_00_ACLK]
+      connect_bd_net $hbm_aresetn [get_bd_pins $hbm/AXI_00_ARESET_N]
+
+      # create AXI connections
+      for {set i 0} {$i < $num_masters} {incr i} {
+        connect_bd_intf_net [get_bd_intf_pins S_MEM_$i] [get_bd_intf_pins $sc_tree/[format "S%03s_AXI" $i]]
+      }
+      connect_bd_intf_net [get_bd_intf_pins S_MMU] [get_bd_intf_pins $mmu/S_AXI_CTRL]
+      connect_bd_intf_net [get_bd_intf_pins $sc_tree/M000_AXI] [get_bd_intf_pins $mmu/S_AXI_ACC]
+      connect_bd_intf_net [get_bd_intf_pins $mmu/M_AXI_MEM] [get_bd_intf_pins $mmu_mem_sc/S00_AXI]
+      connect_bd_intf_net [get_bd_intf_pins $mmu_mem_sc/M00_AXI] [get_bd_intf_pins $hbm/SAXI_00]
+
+      # connect page fault interrupt
+      connect_bd_net [get_bd_pins $mmu/pgf_intr] [tapasco::ip::add_interrupt "PLATFORM_COMPONENT_MMU_FAULT" "host"]
+
+      current_bd_instance $old_instance
+    }
+    return $args
   }
 }

--- a/toolflow/vivado/platform/AU50/plugins/svm.tcl
+++ b/toolflow/vivado/platform/AU50/plugins/svm.tcl
@@ -135,7 +135,6 @@ namespace eval svm {
       set hbm [get_bd_cells hbm_0]
 
       delete_bd_objs [get_bd_nets dma_IRQ_write] [get_bd_nets dma_IRQ_read] [get_bd_intf_nets S_DMA_1] [get_bd_intf_nets dma_m32_axi] [get_bd_intf_nets dma_m64_axi] [get_bd_cells dma]
-      disconnect_bd_net /memory/memory_clk_wiz_memory_clk [get_bd_pins $mig_ic/aclk]
       disconnect_bd_net /memory/design_clk_1 [get_bd_pins hbm_0/AXI_00_ACLK]
       disconnect_bd_net /memory/design_peripheral_aresetn_1 [get_bd_pins hbm_0/AXI_00_ARESET_N]
 
@@ -177,7 +176,6 @@ namespace eval svm {
       connect_bd_net $design_aclk [get_bd_pins $sc_tree/s_aclk]
       connect_bd_net $pcie_aclk [get_bd_pins $mmu_mem_sc/aclk]
       connect_bd_net $hbm_clk [get_bd_pins $mmu_mem_sc/aclk1]
-      connect_bd_net $pcie_aclk [get_bd_pins $mig_ic/aclk]
       connect_bd_net $hbm_clk [get_bd_pins $hbm/AXI_00_ACLK]
       connect_bd_net $hbm_aresetn [get_bd_pins $hbm/AXI_00_ARESET_N]
 

--- a/toolflow/vivado/platform/AU50/plugins/svm.tcl
+++ b/toolflow/vivado/platform/AU50/plugins/svm.tcl
@@ -1,0 +1,28 @@
+# Copyright (c) 2014-2023 Embedded Systems and Applications, TU Darmstadt.
+#
+# This file is part of TaPaSCo
+# (see https://github.com/esa-tu-darmstadt/tapasco).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+namespace eval svm {
+  proc is_svm_supported {} {
+    return true
+  }
+
+  proc is_network_port_valid {port_no} {
+    return false
+  }
+}

--- a/toolflow/vivado/platform/common/plugins/svm.tcl
+++ b/toolflow/vivado/platform/common/plugins/svm.tcl
@@ -379,7 +379,7 @@ namespace eval svm {
     if {[tapasco::is_feature_enabled "SVM"]} {
       set args [lappend args "M_MMU" [list 0x50000 0x10000 0 "PLATFORM_COMPONENT_MMU"]]
       if {[tapasco::get_feature_option "SVM" "pcie_e2e"] == "true"} {
-        set args [lappend args "M_RDMA" [list 0x2000000000 0 [expr "1 << 38"] ""]]
+        set args [lappend args "M_RDMA" [list 0x2000000000 0 [expr "1 << 37"] ""]]
       }
     }
     return $args

--- a/toolflow/vivado/platform/common/plugins/svm.tcl
+++ b/toolflow/vivado/platform/common/plugins/svm.tcl
@@ -309,6 +309,15 @@ namespace eval svm {
     }
   }
 
+  proc connect_rdma_offset_core {rdma_offset} {
+    # add slave port to mig_ic and connect it to axi_generic_offset
+    set mig_ic [get_bd_cells mig_ic]
+    set num_si_old [get_property CONFIG.NUM_SI $mig_ic]
+    set num_si [expr "$num_si_old + 1"]
+    set_property -dict [list CONFIG.NUM_SI $num_si] $mig_ic
+    connect_bd_intf_net [get_bd_intf_pin $rdma_offset/M_AXI] [get_bd_intf_pin $mig_ic/[format "S%02d_AXI" $num_si_old]]
+  }
+
   proc add_rdma_bar {} {
     if {[tapasco::is_feature_enabled "SVM"] && [tapasco::get_feature_option "SVM" "pcie_e2e"] == "true"} {
       ## host subsystem modifications
@@ -351,11 +360,7 @@ namespace eval svm {
       connect_bd_intf_net $s_rdma [get_bd_intf_pin $rdma_offset/S_AXI]
 
       # add slave port to mig_ic and connect it to axi_generic_offset
-      set mig_ic [get_bd_cells mig_ic]
-      set num_si_old [get_property CONFIG.NUM_SI $mig_ic]
-      set num_si [expr "$num_si_old + 1"]
-      set_property -dict [list CONFIG.NUM_SI $num_si] $mig_ic
-      connect_bd_intf_net [get_bd_intf_pin $rdma_offset/M_AXI] [get_bd_intf_pin $mig_ic/[format "S%02d_AXI" $num_si_old]]
+      connect_rdma_offset_core $rdma_offset
 
       current_bd_instance
     }


### PR DESCRIPTION
Adds platform support for the Alveo U50 to TaPaSCo including following features:

- Use HBM as default memory
- AXI masters in multi-PE composition use independent HBM ports for better performance
- SFP+ features supported for 4x10G and 100G
- SVM extension supported including device-to-device page migrations using PCIe and 100G