### PR TITLE
Enable OPTIMIZE_CLOCKING_STRUCTURE_EN only for UltraScale+

### DIFF
--- a/toolflow/vivado/common/common.tcl
+++ b/toolflow/vivado/common/common.tcl
@@ -667,6 +667,10 @@ namespace eval tapasco {
     return 128
   }
 
+  proc is_virtex_usp {} {
+    return [string match "virtexuplus*" [get_property FAMILY [get_parts -of_objects [current_project]]]]
+  }
+
   proc is_versal {} {
     return [string match "versal*" [get_property FAMILY [get_parts -of_objects [current_project]]]]
   }

--- a/toolflow/vivado/platform/pcie/pcie_base.tcl
+++ b/toolflow/vivado/platform/pcie/pcie_base.tcl
@@ -258,8 +258,11 @@
                         CONFIG.RESET_TYPE {ACTIVE_LOW} \
                         CONFIG.RESET_PORT {resetn} \
                         CONFIG.PRIM_SOURCE {No_buffer} \
-                        CONFIG.OPTIMIZE_CLOCKING_STRUCTURE_EN {true} \
                         ] $design_clk_wiz
+
+    if {[tapasco::is_virtex_usp]} {
+        set_property CONFIG.OPTIMIZE_CLOCKING_STRUCTURE_EN {true} $design_clk_wiz
+    }
 
     connect_bd_net [get_bd_pins $design_clk_wiz/resetn] [get_bd_pins -regexp $mig/((mmcm_locked)|(c0_init_calib_complete))]
     connect_bd_net [get_bd_pins $design_clk_wiz/locked] $design_aresetn


### PR DESCRIPTION
On Virtex-7, Vivado otherwise instantiates a wrong clocking primitive.