### PR TITLE
Feature/axi4mm smartconnect

### DIFF
--- a/documentation/tapasco-features.md
+++ b/documentation/tapasco-features.md
@@ -35,11 +35,11 @@ WrapAXIFull {
 }
 ```
 
-#### AXI4mmUseSmartconnect
-This feature is specific to the AXI4MM-architecture. It controls whether AXI interconnects or AXI smartconnects are used for control AND data aggregation in the architecture. By default AXI interconnects are used (except on VERSAL FPGAs). To use AXI smartconnects instead:
+#### axi4mmUseSmartconnect
+This feature is specific to the axi4mm-architecture. It controls whether AXI interconnects or AXI smartconnects are used for control AND data aggregation in the architecture. By default AXI interconnects are used (except on VERSAL FPGAs). To use AXI smartconnects instead:
 
 ```
-AXI4mmUseSmartconnect {
+axi4mmUseSmartconnect {
   enabled: true
 }
 ```

--- a/documentation/tapasco-features.md
+++ b/documentation/tapasco-features.md
@@ -34,6 +34,17 @@ WrapAXIFull {
   enabled: false
 }
 ```
+
+#### AXI4mmUseSmartconnect
+This feature is specific to the AXI4MM-architecture. It controls whether AXI interconnects or AXI smartconnects are used for control AND data aggregation in the architecture. By default AXI interconnects are used (except on VERSAL FPGAs). To use AXI smartconnects instead:
+
+```
+AXI4mmUseSmartconnect {
+  enabled: true
+}
+```
+
+
 ## Zynq based platforms
 
 ### ZC706

--- a/documentation/tapasco-features.md
+++ b/documentation/tapasco-features.md
@@ -26,6 +26,14 @@ microblaze {
 }
 ```
 
+#### WrapAXIFull
+This determines whether potential AXI4-Full slave ports of the PEs are wrapped (i.e. converted to AXI4-Lite) before connecting them to the interconnect tree. By default this is activated, so all AXI4-Full slave ports are wrapped. This can be deactivated using:
+
+```
+WrapAXIFull {
+  enabled: false
+}
+```
 ## Zynq based platforms
 
 ### ZC706

--- a/toolflow/vivado/arch/axi4mm/axi4mm.tcl
+++ b/toolflow/vivado/arch/axi4mm/axi4mm.tcl
@@ -133,7 +133,7 @@ namespace eval arch {
 
     # bypass existing AXI4Lite slaves
     set slave_ports [list]
-    set lites [get_bd_intf_pins -of_objects $inst -filter {MODE == Slave}]
+    set lites [get_bd_intf_pins -of_objects $inst -filter {MODE == Slave && (CONFIG.PROTOCOL == AXI4 || CONFIG.PROTOCOL == AXI4LITE)}]
     foreach ls $lites {
       set op [create_bd_intf_pin -vlnv "xilinx.com:interface:aximm_rtl:1.0" -mode Slave [get_property NAME $ls]]
       connect_bd_intf_net $op $ls

--- a/toolflow/vivado/arch/axi4mm/axi4mm.tcl
+++ b/toolflow/vivado/arch/axi4mm/axi4mm.tcl
@@ -225,7 +225,7 @@ namespace eval arch {
     # generate output trees
     for {set i 0} {$i < [llength $mdist]} {incr i} {
       puts "  mdist[$i] = [lindex $mdist $i]"
-      if {[tapasco::is_versal]} {
+      if {[tapasco::is_versal] || [tapasco::get_feature_option "AXI4mmUseSmartconnect" "enabled" false]} {
         set out [tapasco::create_smartconnect_tree "out_$i" [lindex $mdist $i]]
       } else {
         set out [tapasco::create_interconnect_tree "out_$i" [lindex $mdist $i]]
@@ -254,7 +254,7 @@ namespace eval arch {
       puts "Connecting one slave to host"
       return $out_port
     } {
-      if {[tapasco::is_versal]} {
+      if {[tapasco::is_versal] || [tapasco::get_feature_option "AXI4mmUseSmartconnect" "enabled" false]} {
         set in1 [tapasco::create_smartconnect_tree "in1" $ic_s false]
       } else {
         set in1 [tapasco::create_interconnect_tree "in1" $ic_s false]

--- a/toolflow/vivado/arch/axi4mm/axi4mm.tcl
+++ b/toolflow/vivado/arch/axi4mm/axi4mm.tcl
@@ -225,7 +225,7 @@ namespace eval arch {
     # generate output trees
     for {set i 0} {$i < [llength $mdist]} {incr i} {
       puts "  mdist[$i] = [lindex $mdist $i]"
-      if {[tapasco::is_versal] || [tapasco::get_feature_option "AXI4mmUseSmartconnect" "enabled" false]} {
+      if {[tapasco::is_versal] || [tapasco::get_feature_option "axi4mmUseSmartconnect" "enabled" false]} {
         set out [tapasco::create_smartconnect_tree "out_$i" [lindex $mdist $i]]
       } else {
         set out [tapasco::create_interconnect_tree "out_$i" [lindex $mdist $i]]
@@ -254,7 +254,7 @@ namespace eval arch {
       puts "Connecting one slave to host"
       return $out_port
     } {
-      if {[tapasco::is_versal] || [tapasco::get_feature_option "AXI4mmUseSmartconnect" "enabled" false]} {
+      if {[tapasco::is_versal] || [tapasco::get_feature_option "axi4mmUseSmartconnect" "enabled" false]} {
         set in1 [tapasco::create_smartconnect_tree "in1" $ic_s false]
       } else {
         set in1 [tapasco::create_interconnect_tree "in1" $ic_s false]

--- a/toolflow/vivado/arch/axi4mm/axi4mm.tcl
+++ b/toolflow/vivado/arch/axi4mm/axi4mm.tcl
@@ -132,14 +132,14 @@ namespace eval arch {
     set bd_inst [current_bd_instance .]
 
     # bypass existing AXI4Lite slaves
-    set lite_ports [list]
-    set lites [get_bd_intf_pins -of_objects $inst -filter {MODE == Slave && CONFIG.PROTOCOL == AXI4LITE}]
+    set slave_ports [list]
+    set lites [get_bd_intf_pins -of_objects $inst -filter {MODE == Slave}]
     foreach ls $lites {
       set op [create_bd_intf_pin -vlnv "xilinx.com:interface:aximm_rtl:1.0" -mode Slave [get_property NAME $ls]]
       connect_bd_intf_net $op $ls
-      lappend lite_ports $ls
+      lappend slave_ports $ls
     }
-    puts "lite_ports = $lite_ports"
+    puts "slave_ports = $slave_ports"
 
     # create master ports
     set maxi_ports [list]

--- a/toolflow/vivado/arch/axi4mm/plugins/full_axi_slave_wrapper.tcl
+++ b/toolflow/vivado/arch/axi4mm/plugins/full_axi_slave_wrapper.tcl
@@ -19,6 +19,11 @@
 
 namespace eval full_axi_wrapper {
   proc wrap_full_axi_interfaces {inst {args {}}} {
+    if {![tapasco::get_feature_option "WrapAXIFull" "enabled" true]} {
+      puts "  Wrapping of AXI4-Full slaves on PEs disabled, skipping..."
+      return [list $inst $args]
+    }
+
     # check interfaces: AXI3/AXI4 slaves will be wrappped
     set inst [get_bd_cells $inst]
     set full_slave_ifs [get_bd_intf_pins -of_objects $inst -filter {MODE == Slave && (CONFIG.PROTOCOL == AXI3 || CONFIG.PROTOCOL == AXI4)}]

--- a/toolflow/vivado/platform/xupvvh-es/check_version.tcl
+++ b/toolflow/vivado/platform/xupvvh-es/check_version.tcl
@@ -1,0 +1,4 @@
+if { [::tapasco::vivado_is_newer "2020.1"] == 1 } {
+  puts "Vivado [version -short] is too new to support xupvvh-es."
+  exit 1
+}

--- a/toolflow/vivado/platform/xupvvh/xupvvh.tcl
+++ b/toolflow/vivado/platform/xupvvh/xupvvh.tcl
@@ -21,6 +21,8 @@ namespace eval platform {
   set platform_dirname "xupvvh"
   set pcie_width "x16"
 
+  source $::env(TAPASCO_HOME_TCL)/platform/${platform_dirname}/check_version.tcl
+
   source $::env(TAPASCO_HOME_TCL)/platform/pcie/pcie_base.tcl
 
   if {[tapasco::is_feature_enabled "HBM"]} {

--- a/toolflow/vivado/platform/zedboard/zedboard.tcl
+++ b/toolflow/vivado/platform/zedboard/zedboard.tcl
@@ -20,6 +20,12 @@
 source -notrace $::env(TAPASCO_HOME_TCL)/platform/zynq/zynq.tcl
 
 namespace eval ::platform {
+
+  if { [::tapasco::vivado_is_newer "2021.1"] == 1 } {
+    puts "Vivado [version -short] is too new to support zedboard."
+    exit 1
+  }
+
   foreach f [glob -nocomplain -directory "$::env(TAPASCO_HOME_TCL)/platform/zedboard/plugins" "*.tcl"] {
     puts "Found plugin: $f"
     source -notrace $f


### PR DESCRIPTION
This PR adds two features:

- AXI4mmUseSmartconnect: allows to use AXI smartconnects for control and data aggregators (instead of interconnects)
- WrapAXIFull: allows to disable the automatic wrapping of AXI4-Full slaves on PEs

Furthermore this PR adds checks for the correct Vivado versions to zedboard and xupvvh-es.