### PR TITLE
Add functions to access PE-local memories to CPP API

### DIFF
--- a/runtime/libtapasco/src/device.rs
+++ b/runtime/libtapasco/src/device.rs
@@ -25,7 +25,7 @@ use crate::dma_user_space::UserSpaceDMA;
 use crate::job::Job;
 use crate::pe::PEId;
 use crate::pe::PE;
-use crate::scheduler::Scheduler;
+use crate::scheduler::{Scheduler,SinglePEHandler};
 use crate::tlkm::{tlkm_access, tlkm_ioctl_svm_launch, tlkm_svm_init_cmd};
 use crate::tlkm::tlkm_ioctl_create;
 use crate::tlkm::tlkm_ioctl_destroy;
@@ -517,6 +517,23 @@ impl Device {
         let pe = self.scheduler.acquire_pe(id).context(SchedulerSnafu)?;
         trace!("Successfully acquired PE of type {}.", id);
         Ok(Job::new(pe, &self.scheduler))
+    }
+
+
+    /// Acquires a PE from the device for use with the [`SinglePEHandler`].
+    /// This will remove the PE from the normal scheduling process (until it is explicitly released).
+    /// The [`SinglePEHandler`] allows to repeatedly launch jobs on this PE. It also allows to manually access the PE-local memory.
+    ///
+    /// # Arguments
+    ///   * id: The ID of the desired PE.
+    ///
+    /// Returns a [`SinglePEHandler`] with the given PE.
+    pub fn acquire_single_pe_scheduler(&self, id: PEId) -> Result<SinglePEHandler> {
+        self.check_exclusive_access()?;
+        trace!("Trying to acquire PE of type {} for SinglePEScheduler.", id);
+        let pe = self.scheduler.acquire_pe(id).context(SchedulerSnafu)?;
+        trace!("Successfully acquired PE of type {}.", id);
+        Ok(SinglePEHandler::new(pe, &self.scheduler))
     }
 
     /// Request a PE from the device but don't create a Job for it. Usually [`acquire_pe`] is used

--- a/runtime/libtapasco/src/job.rs
+++ b/runtime/libtapasco/src/job.rs
@@ -23,7 +23,7 @@ use crate::device::DataTransferPrealloc;
 use crate::device::PEParameter;
 use crate::pe::CopyBack;
 use crate::pe::PE;
-use crate::scheduler::Scheduler;
+use crate::scheduler::ReleasePE;
 use snafu::ResultExt;
 use std::sync::Arc;
 
@@ -82,7 +82,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug)]
 pub struct Job {
     pe: Option<PE>,
-    scheduler: Arc<Scheduler>,
+    scheduler: Arc<dyn ReleasePE>,
 }
 
 /// Release the PE if it's no longer needed.
@@ -103,7 +103,7 @@ impl Job {
     /// Not used directly. Request a Job through [`acquire_pe`].
     ///
     /// [`acquire_pe`]: ../device/struct.Device.html#method.acquire_pe
-    pub fn new(pe: PE, scheduler: &Arc<Scheduler>) -> Self {
+    pub fn new(pe: PE, scheduler: &Arc<impl ReleasePE + 'static>) -> Self {
         Self {
             pe: Some(pe),
             scheduler: scheduler.clone(),

--- a/runtime/libtapasco/src/scheduler.rs
+++ b/runtime/libtapasco/src/scheduler.rs
@@ -23,6 +23,7 @@ use crate::debug::{DebugGenerator, NonDebugGenerator};
 use crate::device::OffchipMemory;
 use crate::pe::PEId;
 use crate::pe::PE;
+use crate::job::Job;
 use crossbeam::deque::{Injector, Steal};
 use lockfree::map::Map;
 use memmap::MmapMut;
@@ -32,6 +33,7 @@ use std::collections::VecDeque;
 use std::fs::File;
 use std::sync::Arc;
 use std::thread;
+use core::fmt::Debug;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -56,9 +58,16 @@ pub enum Error {
 
     #[snafu(display("Debug Error: {}", source))]
     DebugError { source: crate::debug::Error },
+
+    #[snafu(display("Local memory requested on PE without local memory"))]
+    NoLocalMemory {},
 }
 
 type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub trait ReleasePE: Debug {
+    fn release_pe(&self, pe: PE) -> Result<()>;
+}
 
 /// Main method to retrieve a PE for execution
 ///
@@ -180,15 +189,6 @@ impl Scheduler {
         }
     }
 
-    pub fn release_pe(&self, pe: PE) -> Result<()> {
-        ensure!(!pe.active(), PEStillActiveSnafu { pe });
-
-        match self.pes.get(pe.type_id()) {
-            Some(l) => l.val().push(pe),
-            None => return Err(Error::NoSuchPE { id: *pe.type_id() }),
-        }
-        Ok(())
-    }
 
     pub fn reset_interrupts(&self) -> Result<()> {
         for v in self.pes.iter() {
@@ -230,4 +230,105 @@ impl Scheduler {
             possible: self.pes_name.values().cloned().collect(),
         })
     }
+}
+
+impl ReleasePE for Scheduler {
+    fn release_pe(&self, pe: PE) -> Result<()> {
+        ensure!(!pe.active(), PEStillActiveSnafu { pe });
+
+        match self.pes.get(pe.type_id()) {
+            Some(l) => l.val().push(pe),
+            None => return Err(Error::NoSuchPE { id: *pe.type_id() }),
+        }
+        Ok(())
+    }
+}
+
+
+#[derive(Debug)]
+pub struct SinglePEHandler {
+    scheduler: Arc<SinglePEScheduler>,
+    release: Arc<dyn ReleasePE>,
+    released: bool,
+}
+
+#[derive(Debug)]
+pub struct SinglePEScheduler {
+    pe: Injector<PE>,
+    local_memory: Option<Arc<OffchipMemory>>,
+}
+
+impl SinglePEHandler {
+    pub fn new(
+        pe: PE,
+        release: &Arc<impl ReleasePE + 'static>,
+    ) -> Self {
+        SinglePEHandler {
+            scheduler: Arc::new(SinglePEScheduler::new(pe)),
+            release: release.clone(),
+            released: false
+        }
+    }
+
+    pub fn acquire_pe(&self) -> Result<Job> {
+        if self.released {
+            Err(Error::PEUnavailable {id: 0 })
+        } else {
+            Ok(Job::new(self.scheduler.acquire_pe(), &self.scheduler))
+        }
+    }
+
+    pub fn get_local_memory(&self) -> Result<&Arc<OffchipMemory>, Error> {
+        self.scheduler.get_local_memory()
+    }
+
+    pub fn release_pe(&mut self) -> Result<()> {
+        if !self.released {
+            self.released = true;
+            self.release.release_pe(self.scheduler.acquire_pe())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl SinglePEScheduler {
+    pub fn new(
+        pe: PE,
+    ) -> Self {
+        let v = Injector::new();
+        let memory = pe.local_memory().clone();
+        v.push(pe);
+        SinglePEScheduler {
+            pe: v,
+            local_memory: memory,
+        }
+    }
+
+    pub fn acquire_pe(&self) -> PE {
+        loop {
+            match self.pe.steal() {
+                Steal::Success(pe) => return pe,
+                Steal::Empty => (),
+                Steal::Retry => (),
+            }
+            thread::yield_now();
+        }
+    }
+
+    pub fn get_local_memory(&self) -> Result<&Arc<OffchipMemory>, Error> {
+        match &self.local_memory {
+            Some(m) => Ok(m),
+            None => Err(Error::NoLocalMemory {}),
+        }
+    }
+}
+
+impl ReleasePE for SinglePEScheduler {
+
+    fn release_pe(&self, pe: PE) -> Result<()> {
+        self.pe.push(pe);
+        Ok(())
+    }
+
 }

--- a/runtime/libtapasco/src/tapasco.hpp
+++ b/runtime/libtapasco/src/tapasco.hpp
@@ -389,6 +389,14 @@ public:
     return j;
   }
 
+  TapascoMemory get_pe_local_memory(PEId pe_id) {
+    TapascoOffchipMemory *mem = tapasco_device_get_pe_local_memory(this->device, pe_id);
+    if (mem == 0) {
+      handle_error();
+    }
+    return TapascoMemory(mem);
+  }
+
   float design_frequency() {
     return tapasco_device_design_frequency(this->device);
   }


### PR DESCRIPTION
This adds some functions to the C++ API, which allow to remove a PE (with a given PEID) from the scheduler (so it can't be used by normal `launch()` calls anymore).
After removing the PE from the scheduler, it is available as a "standalone PE", allowing to manually handle this PE.
A manually handled PE allows the user to start jobs on it and access it's PE-local memory.

This allows to main things (which are not possible with the standard scheduler and `launch()`):
- Launch multiple, sequential jobs on the same PE instance (e.g. if the PE keeps local state).
- Manually access (read/write) the PE-local memory from the host software.

Short example of using this:
```
auto pe = tapasco.acquire_pe_without_job(PEID);
pe->get_local_memory().copy_to() // Same arguments as with standard copy_to()
pe->launch(...); // Same arguments as with standard launch()
...
pe->release(); // Return the PE to the normal scheduler
```