### PR TITLE
fix zynqmp bus error

### DIFF
--- a/runtime/libtapasco/src/device.rs
+++ b/runtime/libtapasco/src/device.rs
@@ -459,7 +459,7 @@ impl Device {
                             allocator: Mutex::new(Box::new(
                                 GenericAllocator::new(0, l.size, 1).context(AllocatorSnafu)?,
                             )),
-                            dma: Box::new(DirectDMA::new(l.base, l.size, arch.clone())),
+                            dma: Box::new(DirectDMA::new(l.base, l.size, arch.clone(), name.clone())),
                         }));
                     },
                     None => (),

--- a/runtime/libtapasco/src/dma.rs
+++ b/runtime/libtapasco/src/dma.rs
@@ -238,7 +238,6 @@ impl DMAControl for DirectDMA {
             
             //on armv8 unaligned accesses to device memory result in a bus error
             if self.dev_name == "zynqmp" {
-                let aligned_size = data.len() / 8;
                 let remaining_bytes = data.len() % 8;
                 let aligned_bytes = data.len() - remaining_bytes;
                 let unaligned = remaining_bytes != 0;

--- a/runtime/libtapasco/src/dma.rs
+++ b/runtime/libtapasco/src/dma.rs
@@ -207,7 +207,7 @@ impl DirectDMA {
             offset,
             size,
             memory,
-            dev_name: dev_name
+            dev_name,
         }
     }
 }

--- a/runtime/libtapasco/src/dma.rs
+++ b/runtime/libtapasco/src/dma.rs
@@ -198,14 +198,16 @@ pub struct DirectDMA {
     offset: DeviceAddress,
     size: DeviceSize,
     memory: Arc<MmapMut>,
+    dev_name: String,
 }
 
 impl DirectDMA {
-    pub fn new(offset: DeviceAddress, size: DeviceSize, memory: Arc<MmapMut>) -> Self {
+    pub fn new(offset: DeviceAddress, size: DeviceSize, memory: Arc<MmapMut>, dev_name: String) -> Self {
         Self {
             offset,
             size,
             memory,
+            dev_name: dev_name
         }
     }
 }
@@ -233,10 +235,32 @@ impl DMAControl for DirectDMA {
         // Locking the mmap would slow down PE start etc too much
         unsafe {
             let p = self.memory.as_ptr().offset((self.offset + ptr) as isize) as *mut u8;
-            let s = std::ptr::slice_from_raw_parts_mut(p, data.len());
-            (*s).clone_from_slice(data);
-        }
+            
+            //on armv8 unaligned accesses to device memory result in a bus error
+            if self.dev_name == "zynqmp" {
+                let aligned_size = data.len() / 8;
+                let remaining_bytes = data.len() % 8;
+                let aligned_bytes = data.len() - remaining_bytes;
+                let unaligned = remaining_bytes != 0;
+                
+                //use clone_from_slice for the aligned portion of the data to
+                //maintain fast transfer speeds
+                let s: *mut [u8] = std::ptr::slice_from_raw_parts_mut(p, aligned_bytes);
+                (*s).clone_from_slice(&data[..(aligned_bytes)]);
 
+                if unaligned {
+                    let rem_s: *mut [u8] = std::ptr::slice_from_raw_parts_mut(p.offset(aligned_bytes as isize), remaining_bytes);
+                    //transfer the remaining bytes individually
+                    for i in 0..remaining_bytes {
+                        (*rem_s)[i] = data[i];
+                    }
+                }
+            } else {
+                let s: *mut [u8] = std::ptr::slice_from_raw_parts_mut(p, data.len());
+                (*s).clone_from_slice(data);                
+            }
+            
+        }
         Ok(())
     }
 


### PR DESCRIPTION

The current `DirectDMA` `copy_to` implementation does not work on ZynqMP for transfer amounts  not aligned to 8 bytes. Such transfers result in a bus error. 

To avoid this, the data now gets split into a large chunk, which is of an aligned amount and a small chunk, consisting of all remaining bytes. The remaining bytes will get transferred individually with a simple for loop (there are at most 7 remaining bytes).
I also tried using a separate `clone_from_slice` call for the remaining bytes but this again resulted in a bus error.

Since the primary purpose of this PR was to fix issue #339 , I haven't checked `copy_from` yet, which most likely does not work for unaligned transfer amounts either. The same fix could be employed there but would have to be tested first.<br>

The reason for the bus error is that on armv8 unaligned access to memory classed as "device" is not allowed \[[1]\]. The unaligned access is a result of the function `clone_from_slice` which, since the data has type `u8`, will directly call `copy_from_slice` \[[2]\]. This in turn will be transformed into a `memcpy` \[[3]\].
Looking at the `memcpy` implementation for aarch64, one can see that the last 64 bytes are transferred with addresses calculated from the back, meaning an unaligned address will result for unaligned amounts of data \[[4]\]. This is consistent with my observation that the bus error only occurs when most of the data has already been transferred.


[1]: https://developer.arm.com/documentation/ka004708/latest/
[2]: https://github.com/rust-lang/rust/blob/90c541806f23a127002de5b4038be731ba1458ca/library/core/src/slice/mod.rs#L4396
[3]: https://doc.rust-lang.org/std/primitive.slice.html#method.copy_from_slice
[4]: https://github.com/ARM-software/optimized-routines/blob/master/string/aarch64/memcpy.S