### PR TITLE
Remove intptr_t declaration

### DIFF
--- a/runtime/kernel/user/tlkm_types.h
+++ b/runtime/kernel/user/tlkm_types.h
@@ -26,11 +26,9 @@ typedef uint32_t u32;
 typedef int32_t s32;
 typedef uint64_t u64;
 typedef int64_t s64;
-#else
-typedef uintptr_t intptr_t;
 #endif
 
 typedef u32 dev_id_t;
-typedef intptr_t dev_addr_t;
+typedef uintptr_t dev_addr_t;
 
 #endif /* TLKM_TYPES_H__ */


### PR DESCRIPTION
Declaration is conflicting with declaration in linux kernel 6.5 and newer. Also it is misleading and
 only used once, so declare dev_addr_t directly as uintptr_t.