### PR TITLE
Fix wrapping of AXI (full) slaves

### DIFF
--- a/toolflow/vivado/arch/axi4mm/axi4mm.tcl
+++ b/toolflow/vivado/arch/axi4mm/axi4mm.tcl
@@ -132,14 +132,14 @@ namespace eval arch {
     set bd_inst [current_bd_instance .]
 
     # bypass existing AXI4Lite slaves
-    set slave_ports [list]
-    set lites [get_bd_intf_pins -of_objects $inst -filter {MODE == Slave && (CONFIG.PROTOCOL == AXI4 || CONFIG.PROTOCOL == AXI4LITE)}]
+    set lite_ports [list]
+    set lites [get_bd_intf_pins -of_objects $inst -filter {MODE == Slave && CONFIG.PROTOCOL == AXI4LITE}]
     foreach ls $lites {
       set op [create_bd_intf_pin -vlnv "xilinx.com:interface:aximm_rtl:1.0" -mode Slave [get_property NAME $ls]]
       connect_bd_intf_net $op $ls
-      lappend slave_ports $ls
+      lappend lite_ports $ls
     }
-    puts "slave_ports = $slave_ports"
+    puts "lite_ports = $lite_ports"
 
     # create master ports
     set maxi_ports [list]

--- a/toolflow/vivado/arch/axi4mm/plugins/full_axi_slave_wrapper.tcl
+++ b/toolflow/vivado/arch/axi4mm/plugins/full_axi_slave_wrapper.tcl
@@ -19,10 +19,6 @@
 
 namespace eval full_axi_wrapper {
   proc wrap_full_axi_interfaces {inst {args {}}} {
-    if {![tapasco::get_feature_option "WrapAXIFull" "enabled" true]} {
-      puts "  Wrapping of AXI4-Full slaves on PEs disabled, skipping..."
-      return [list $inst $args]
-    }
 
     # check interfaces: AXI3/AXI4 slaves will be wrappped
     set inst [get_bd_cells $inst]
@@ -35,16 +31,26 @@ namespace eval full_axi_wrapper {
 
     set bd_inst [current_bd_instance .]
 
-    # rewire full slaves
-    set si 0
-    foreach fs $full_slave_ifs {
-      # create slave port
-      set saxi_port [create_bd_intf_pin -vlnv "xilinx.com:interface:aximm_rtl:1.0" -mode Slave "S_AXI_LITE_$si"]
-      set conv [tapasco::ip::create_proto_conv "conv_$si" "AXI4LITE" [get_property CONFIG.PROTOCOL $fs]]
-      connect_bd_intf_net $saxi_port [get_bd_intf_pins -of_objects $conv -filter {MODE == Slave}]
-      connect_bd_intf_net [get_bd_intf_pins -filter {MODE == Master} -of_objects $conv] $fs
 
-      incr si
+    if {![tapasco::get_feature_option "WrapAXIFull" "enabled" true]} {
+      foreach fs $full_slave_ifs {
+        set op [create_bd_intf_pin -vlnv "xilinx.com:interface:aximm_rtl:1.0" -mode Slave [get_property NAME $fs]]
+        connect_bd_intf_net $op $fs
+      }
+    } else {
+
+      # rewire full slaves
+      set si 0
+      foreach fs $full_slave_ifs {
+        # create slave port
+        set saxi_port [create_bd_intf_pin -vlnv "xilinx.com:interface:aximm_rtl:1.0" -mode Slave "S_AXI_LITE_$si"]
+        set conv [tapasco::ip::create_proto_conv "conv_$si" "AXI4LITE" [get_property CONFIG.PROTOCOL $fs]]
+        connect_bd_intf_net $saxi_port [get_bd_intf_pins -of_objects $conv -filter {MODE == Slave}]
+        connect_bd_intf_net [get_bd_intf_pins -filter {MODE == Master} -of_objects $conv] $fs
+
+        incr si
+      }
+
     }
 
     


### PR DESCRIPTION
This fixes errors during compose with AXI (full) slave interfaces.

This reverts part of #356, so that the base architecture (axi4mm) only bypasses AXI4-Lite interfaces.
AXI4-Full interfaces are always handled in the AXI-Wrapper-Plugin: Depending of the setting of the Feature, AXI4-Full interfaces are either converted to AXI4-Lite or also just bypassed (default is convert to AXI4-Lite).