### PR TITLE
Provide better error message for small bitwidth arguments

### DIFF
--- a/runtime/libtapasco/src/tapasco.hpp
+++ b/runtime/libtapasco/src/tapasco.hpp
@@ -287,8 +287,10 @@ private:
       this->single32((uint32_t)t);
     } else if (sizeof(T) == 8) {
       this->single64((uint64_t)t);
-    } else {
+    } else if (sizeof(T) > 8) {
       throw tapasco_error("Please supply large arguments as wrapped pointers.");
+    } else {
+      throw tapasco_error("TaPaSCo supports 32 or 64 bit argument types or buffers. You provided an argument smaller than 32 bits.");
     }
   }
 


### PR DESCRIPTION
This PR fixes #372. We now check in the C++ API if the provided argument type is smaller than 32 bit and tell the user quite clearly what is wrong.  