### PR TITLE
Fix error handling in acquire_pe_without_job

### DIFF
--- a/runtime/libtapasco/src/tapasco.hpp
+++ b/runtime/libtapasco/src/tapasco.hpp
@@ -620,7 +620,6 @@ public:
 
   TapascoPE *acquire_pe_without_job(PEId pe_id) {
     SinglePEHandler *pe = tapasco_device_acquire_pe_without_job(this->device, pe_id);
-    std::cout << "PE: " << pe << std::endl;
     if (pe == 0) {
       handle_error();
     }


### PR DESCRIPTION
This removes a leftover debug output from `acquire_pe_without_job()`.
In case of a failure to acquire the PE this debug output prevented the printing of the actual error message (as it caused a SegFault).