### PR TITLE
Add sim IOCTL prototypes

### DIFF
--- a/runtime/kernel/sim/sim_ioctl.c
+++ b/runtime/kernel/sim/sim_ioctl.c
@@ -29,6 +29,13 @@
 #include "tlkm_device.h"
 #include "tlkm_device_ioctl_cmds.h"
 #include "sim_device.h"
+#include "sim/sim_ioctl.h"
+
+long sim_ioctl_dma_buffer_allocate(struct tlkm_device *inst, struct tlkm_dma_buffer_allocate __user *param);
+long sim_ioctl_dma_buffer_free(struct tlkm_device *inst, struct tlkm_dma_buffer_op __user *param);
+long sim_ioctl_dma_buffer_to_dev(struct tlkm_device *inst, struct tlkm_dma_buffer_op __user *param);
+long sim_ioctl_dma_buffer_from_dev(struct tlkm_device *inst, struct tlkm_dma_buffer_op __user *param);
+
 
 static inline long sim_ioctl_info(struct tlkm_device *inst,
 				   struct tlkm_device_info *info)

--- a/runtime/kernel/sim/sim_ioctl.h
+++ b/runtime/kernel/sim/sim_ioctl.h
@@ -22,9 +22,8 @@
 //!
 #ifndef SIM_IOCTL_H__
 #define SIM_IOCTL_H__
-
 #include "tlkm_device.h"
 
-long sim_ioctl(struct tlkm_device *inst, unsigned ioctl, unsigned long data);
+long sim_ioctl(struct tlkm_device *inst, unsigned int ioctl, unsigned long data);
 
 #endif /* SIM_IOCTL_H__ */


### PR DESCRIPTION
Missing prototypes caused the TLKM build to fail when building with simulation support for the runtime (and driver).

You can test the succeeding build with

```sh
tapasco-build-libs --enable_sim=runtime
```