### PR TITLE
Hotfix: rustc 1.80.0 fatal runtime error

### DIFF
--- a/runtime/libtapasco/src/interrupt.rs
+++ b/runtime/libtapasco/src/interrupt.rs
@@ -64,7 +64,6 @@ pub struct Interrupt {
 
 impl Drop for SimInterrupt {
     fn drop(&mut self) {
-        let _ = close(self.interrupt.as_raw_fd());
         trace!("deregistering interrupt: {:?}", self.interrupt);
         let _ = self.client.deregister_interrupt(DeregisterInterrupt { fd: self.interrupt.as_raw_fd() }).context(SimClientSnafu);
     }
@@ -72,7 +71,6 @@ impl Drop for SimInterrupt {
 
 impl Drop for Interrupt {
     fn drop(&mut self) {
-        let _ = close(self.interrupt.as_raw_fd());
         trace!("deregistering interrupt: {:?}", self.interrupt);
     }
 }


### PR DESCRIPTION
As of rustc 1.80.0 running tapasco runtime with debug enabled will crash with
`fatal runtime error: IO Safety violation: owned file descriptor already closed`

This is due to a change in rust PR [124210](https://github.com/rust-lang/rust/pull/124210), which aborts a process when fd ownership is violated (as is the case when e.g. double closing an fd).

Tapasco closes each interrupt fd twice:
1. `interrupt.rs`: `let _ = close(self.interrupt.as_raw_fd());` in the Tapasco-Interrupt Drop implementation.
2. `nix::eventfd::EventFd`: Tapasco uses EventFd to wrap the underlying fd safely, i.e. it closes the fd automatically when going out of scope.

This PR removes the call to `close(eventfd)` in `interrupt.rs` for Interrupt (tested) and SimInterrupt (untested).

Since there is no `impl Drop for EventFd` in the [nix-rust Repository](https://github.com/nix-rust/nix/tree/master), I verified that it nonetheless closes the fd by listing open fds using `ls -l /proc/<proc_id>/fd/` at different points during runtime.
