### PR TITLE
Add option to disable PCIe link

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Getting Started - Build a TaPaSCo design
     *   HDL flow: `tapasco import path/to/ZIP as <ID> -p <PLATFORM>` will import the corresponding ZIP file as a new HDL-based core. The Kernel-ID is set from <ID> and the optional flag `-p <PLATFORM>` determines for which platform the kernel will be available. If it is omitted, it will be made available for all platforms which may take a lot of time.
     *   HLS flow: `tapasco hls <KERNEL> -p <PLATFORM>` will perform hls according to the `kernel.json`. The resulting HLS-based core will be made available for the platform given by `-p <PLATFORM>`. Again, `-p` can be omitted. HLS-Kernels are generally located in `$TAPASCO_WORKDIR/kernel`. If you want to add kernels you can create either symlink or copy them into the folder. Additionally, the folder can be temporarily changed using the optional `--kernelDir path/to/kernels` flag like this: `tapasco --kernelDir path/to/kernels hls <KERNEL> -p <PLATFORM>`
 2.  Create a composition: `tapasco compose [<KERNEL> x <COUNT>] @ <NUM> MHz -p <PLATFORM>`
-3.  Load the bitstream: `tapasco-load-bitstream <BITSTREAM>`
+3.  Load the bitstream (see below for more details): `tapasco-load-bitstream <BITSTREAM>`
 4.  Implement your host software
     *   C API
     *   C++ API
@@ -183,6 +183,15 @@ Getting Started - Build a Software-Interface
 2.  Load your bitstream: `tapasco-load-bitstream my-design.bit --reload-driver`. To do this, you have to source `vivado` and `tapasco-setup.sh`.
 3.  Write a C/C++ executable that interfaces with your design accordingly. To get a better understanding of this, you might want to refer to the collection of examples and the corresponding README which is located in `$TAPASCO_HOME/runtime/examples`
 4.  Build and Compile your Software.
+
+### Tips and Tricks for Server Environments
+
+- Always use the `--reload-driver` option to ensure correct user access permissions for the device file after programming.
+- If multiple devices are attached to the same server, you must select the correct programming adapter using the `--adapter <adapter_id>` argument of `tapasco-load-bitstream`. You can list all available adapters with `tapasco-load-bitstream my-design.bit --verbose --list-adapters`. Using only the last few characters of the adapter ID is sufficient.
+- Recent server CPUs often handle PCIe errors more strictly. Reprogramming the FPGA may trigger a system reboot or cause the device to no longer be detected afterward. To mitigate this, use the `--disable-link` argument with the PCIe BDF of the FPGA, which temporarily disables the PCIe link during programming. You can find the PCIe BDF using `lspci` by looking for Xilinx devices in the output. A complete command may look like this:
+```
+tapasco-load-bitstream my-design.bit --verbose --reload-driver --adapter 3HNA --disable-link 0000:71:00.0
+```
 
 Getting Started - Build a Boot Image
 --------------------------------------------

--- a/runtime/bin/tapasco-load-bitstream
+++ b/runtime/bin/tapasco-load-bitstream
@@ -67,6 +67,11 @@ parser.add_argument(
     '--list-adapter',
     help='list available programming adapters (PCIe only)',
     action='store_true')
+parser.add_argument(
+    '--disable-link',
+    help='disable downlink in PCIe root port (PCIe only)',
+    metavar='PCIE_BDF',
+    action='store')
 args = parser.parse_args()
 
 if 'TAPASCO_HOME_RUNTIME' not in os.environ:
@@ -107,7 +112,8 @@ program = '-p' if args.mode == 'normal' or args.mode == 'program' else ''
 hotplug = '-h' if args.mode == 'normal' or args.mode == 'hotplug' else ''
 adapter = "-a {}".format(args.adapter) if args.adapter and len(args.adapter) > 0 else ''
 listadapter = '-l' if args.list_adapter else ''
+disablelink = "-r {}".format(args.disable_link) if args.disable_link and len(args.disable_link) > 0 else ''
 
-cmd = '$TAPASCO_HOME_RUNTIME/scripts/$TAPASCO_PLATFORM/bit_reload.sh {0} {1} {2} {3} {4} {5} {6} {7}'.format(
-    verb, reld, nold, hotplug, program, adapter, listadapter, args.bitstream)
+cmd = '$TAPASCO_HOME_RUNTIME/scripts/$TAPASCO_PLATFORM/bit_reload.sh {0} {1} {2} {3} {4} {5} {6} {7} {8}'.format(
+    verb, reld, nold, hotplug, program, adapter, listadapter, disablelink, args.bitstream)
 subprocess.call([cmd], shell=True)

--- a/runtime/scripts/pcie/bit_reload.sh
+++ b/runtime/scripts/pcie/bit_reload.sh
@@ -151,13 +151,13 @@ then
 
 			# get root port and check for existence
 			ROOTPORT=$(basename $(dirname $(readlink -f /sys/bus/pci/devices/$PCIEBDF)))
-			echo "ROOTPORT: $ROOTPORT"
 			if [ ! -d "/sys/bus/pci/devices/$ROOTPORT" ]; then
 				echo "Could not find matching PCIe root port: is PCIe BDF correct?"
 				exit
 			fi
 
 			# disable downlink in PCIe root port
+			echo "Disable down link of PCIe root port $ROOTPORT"
 			sudo setpci -s $ROOTPORT CAP_EXP+0x10.w=10:10
 		fi
 

--- a/runtime/scripts/pcie/bit_reload.sh
+++ b/runtime/scripts/pcie/bit_reload.sh
@@ -43,6 +43,7 @@ Program PCIe based FPGAs in JTAG chain with BITSTREAM.
 	-a <ADAPTER>	select programming adapter
 	-l	list available programming adapters
 	-h	hotplug the device
+	-r <PCIe BDF>	disable PCIe downlink in root port
 EOF
 }
 
@@ -85,10 +86,11 @@ NOLOADD=0
 HOTPLUG=0
 PROGRAM=0
 ADAPTER="NOADAPTER"
+PCIEBDF="NOBDF"
 LISTADAPTER=0
 
 OPTIND=1
-while getopts vdnhpa:l opt; do
+while getopts vdnhpa:lr: opt; do
 	case $opt in
 		v)
 			VERBOSE=1
@@ -110,6 +112,9 @@ while getopts vdnhpa:l opt; do
 			;;
 		l)
 			LISTADAPTER=1
+			;;
+		r)
+			PCIEBDF="$OPTARG"
 			;;
 		*)
 			echo "unknown option: $opt"
@@ -136,6 +141,26 @@ then
 
 	# program the device
 	if [ $LISTADAPTER -gt 0 ] || [ $PROGRAM -gt 0 ]; then
+
+		# check PCIe BDF format and disable downlink
+		if [ "$PCIEBDF" != "NOBDF" ]; then
+			if [[ ! "$PCIEBDF" =~ ^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$ ]]; then
+				echo "PCIe BDF has invalid format: expecting format DDDD:BB:SS.F"
+				exit
+			fi
+
+			# get root port and check for existence
+			ROOTPORT=$(basename $(dirname $(readlink -f /sys/bus/pci/devices/$PCIEBDF)))
+			echo "ROOTPORT: $ROOTPORT"
+			if [ ! -d "/sys/bus/pci/devices/$ROOTPORT" ]; then
+				echo "Could not find matching PCIe root port: is PCIe BDF correct?"
+				exit
+			fi
+
+			# disable downlink in PCIe root port
+			sudo setpci -s $ROOTPORT CAP_EXP+0x10.w=10:10
+		fi
+
 		set +e
 		if [ $LISTADAPTER -gt 0 ] || [ $VERBOSE -gt 0 ]; then
 			vivado -nolog -nojournal -notrace -mode tcl -source $BITLOAD_SCRIPT -tclargs --bit $BITSTREAM --adapter $ADAPTER --list-adapter $LISTADAPTER
@@ -159,6 +184,12 @@ then
 			exit $VIVADORET
 		fi
 		echo "bitstream programmed successfully!"
+
+		# enable downlink in PCIe root port
+		if [ "$PCIEBDF" != "NOBDF" ]; then
+			# enable downlink in PCIe root port
+			sudo setpci -s $ROOTPORT CAP_EXP+0x10.w=00:10
+		fi
 
 	fi
 


### PR DESCRIPTION
Recent servers do not like if a PCIe device falls from the bus and may reboot or loose the device until a reboot. This is exactly what happens when re-programming the FPGA via JTAG. As mitigation the new `--disable-link` option of `tapasco-load-bitstream` allows to disable the PCIe downlink in the root port while programming the FPGA.