### PR TITLE
Feature/os upgrade

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,135 +11,134 @@ stages:
   - build_runtime
   - build_hw
 
-.test_tapasco_centos:
+.test_tapasco:
   stage: test_scala_toolflow
   retry: 2
   dependencies: []
   tags:
     - High
   script:
-    - yum -y install which java-openjdk findutils
     - ./tapasco-init.sh && source tapasco-setup.sh
     - cd ${TAPASCO_HOME_TOOLFLOW}/scala
     - ./gradlew test
+
+.test_tapasco_rockylinux:
+  extends: .test_tapasco
 
 test_tapasco_rockylinux_8:
   image: rockylinux:8
-  extends: .test_tapasco_centos
+  before_script:
+    - dnf -y install which java-17-openjdk-devel findutils
+  extends: .test_tapasco_rockylinux
+
+test_tapasco_rockylinux_9:
+  image: rockylinux:9
+  before_script:
+    - dnf -y install which java-21-openjdk-devel findutils
+  extends: .test_tapasco_rockylinux
+
+test_tapasco_rockylinux_10:
+  image: rockylinux/rockylinux:10
+  before_script:
+    - dnf -y install which java-25-openjdk-devel findutils
+  extends: .test_tapasco_rockylinux
 
 .test_tapasco_ubuntu:
-  stage: test_scala_toolflow
-  retry: 2
-  dependencies: []
-  tags:
-    - High
-  script:
+  before_script:
     - apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install unzip git zip findutils curl default-jdk
-    - ./tapasco-init.sh && source tapasco-setup.sh
-    - cd ${TAPASCO_HOME_TOOLFLOW}/scala
-    - ./gradlew test
-
-test_tapasco_ubuntu_18_04:
-  image: ubuntu:18.04
-  extends: .test_tapasco_ubuntu
-
-test_tapasco_ubuntu_20_04:
-  image: ubuntu:20.04
-  extends: .test_tapasco_ubuntu
+  extends: .test_tapasco
 
 test_tapasco_ubuntu_22_04:
   image: ubuntu:22.04
+  before_script:
+    - apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install unzip git zip findutils curl openjdk-17-jdk
+  extends: .test_tapasco_ubuntu
+
+test_tapasco_ubuntu_24_04:
+  image: ubuntu:24.04
+  extends: .test_tapasco_ubuntu
+
+test_tapasco_ubuntu_26_04:
+  image: ubuntu:26.04
   extends: .test_tapasco_ubuntu
 
 .test_tapasco_fedora:
-  stage: test_scala_toolflow
-  retry: 2
-  tags:
-    - High
-  before_script:
-    - dnf -y install which java-openjdk findutils
-  script:
-    - ./tapasco-init.sh && source tapasco-setup.sh
-    - cd ${TAPASCO_HOME_TOOLFLOW}/scala
-    - ./gradlew test
+  extends: .test_tapasco
 
-test_tapasco_fedora_36:
-  image: fedora:36
+test_tapasco_fedora_44:
+  image: fedora:44
   extends: .test_tapasco_fedora
   before_script:
-  - dnf -y install which findutils java-11-openjdk
+  - dnf -y install which findutils java-25-openjdk-devel
 
-.build_scala_tapasco_centos:
+.build_scala_tapasco:
   stage: build_scala_toolflow
   retry: 2
   dependencies: []
   tags:
     - High
-  before_script:
-    - yum -y install which java-openjdk findutils
+  variables:
+    PACKAGE_TYPE: ""
   script:
     - ./tapasco-init.sh && source tapasco-setup.sh
     - cd ${TAPASCO_HOME_TOOLFLOW}/scala
     - tapasco-build-toolflow
-    - ./gradlew buildRPM
+    - ./gradlew $PACKAGE_TYPE
+
+.build_scala_tapasco_rockylinux:
+  variables:
+    PACKAGE_TYPE: "buildRPM"
   artifacts:
     paths:
       - toolflow/scala/build/distributions/tapasco-2025-12.x86_64.rpm
+  extends: .build_scala_tapasco
 
 build_scala_tapasco_rockylinux_8:
   image: rockylinux:8
-  extends: .build_scala_tapasco_centos
-
-.build_scala_tapasco_fedora:
-  stage: build_scala_toolflow
-  retry: 2
-  dependencies: []
-  tags:
-    - High
   before_script:
-    - dnf -y install which java-openjdk findutils
-  script:
-    - ./tapasco-init.sh && source tapasco-setup.sh
-    - cd ${TAPASCO_HOME_TOOLFLOW}/scala
-    - tapasco-build-toolflow
-    - ./gradlew buildRPM
-  artifacts:
-    paths:
-      - toolflow/scala/build/distributions/tapasco-2025-12.x86_64.rpm
+    - dnf -y install which java-17-openjdk-devel findutils
+  extends: .build_scala_tapasco_rockylinux
 
-build_scala_tapasco_fedora_36:
-  image: fedora:36
-  extends: .build_scala_tapasco_fedora
+build_scala_tapasco_rockylinux_9:
+  image: rockylinux:9
   before_script:
-    - dnf -y install which findutils java-11-openjdk
+    - dnf -y install which java-21-openjdk-devel findutils
+  extends: .build_scala_tapasco_rockylinux
+
+build_scala_tapasco_rockylinux_10:
+  image: rockylinux/rockylinux:10
+  before_script:
+    - dnf -y install which java-25-openjdk-devel findutils
+  extends: .build_scala_tapasco_rockylinux
+
+build_scala_tapasco_fedora_44:
+  image: fedora:44
+  before_script:
+    - dnf -y install which java-25-openjdk-devel findutils
+  extends: .build_scala_tapasco_rockylinux
 
 .build_scala_tapasco_ubuntu:
-  stage: build_scala_toolflow
-  retry: 2
-  dependencies: []
-  tags:
-    - High
+  variables:
+    PACKAGE_TYPE: "buildDEB"
   before_script:
-    - apt-get -y update && apt-get -y install default-jdk findutils
-  script:
-    - ./tapasco-init.sh && source tapasco-setup.sh
-    - cd ${TAPASCO_HOME_TOOLFLOW}/scala
-    - tapasco-build-toolflow
-    - ./gradlew buildDEB
+    - apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install default-jdk findutils
   artifacts:
     paths:
       - toolflow/scala/build/distributions/tapasco_2025-12_amd64.deb
-
-build_scala_tapasco_ubuntu_18_04:
-  image: ubuntu:18.04
-  extends: .build_scala_tapasco_ubuntu
-
-build_scala_tapasco_ubuntu_20_04:
-  image: ubuntu:20.04
-  extends: .build_scala_tapasco_ubuntu
+  extends: .build_scala_tapasco
 
 build_scala_tapasco_ubuntu_22_04:
   image: ubuntu:22.04
+  before_script:
+    - apt-get -y update && DEBIAN_FRONTEND=noninteractive apt-get -y install openjdk-17-jdk findutils
+  extends: .build_scala_tapasco_ubuntu
+
+build_scala_tapasco_ubuntu_24_04:
+  image: ubuntu:24.04
+  extends: .build_scala_tapasco_ubuntu
+
+build_scala_tapasco_ubuntu_26_04:
+  image: ubuntu:26.04
   extends: .build_scala_tapasco_ubuntu
 
 # build kernel module
@@ -160,28 +159,16 @@ build_scala_tapasco_ubuntu_22_04:
     paths:
       - runtime/kernel/tlkm.ko
 
-build_kernel_ubuntu_18_04:
-  image: ubuntu:18.04
-  extends: .build_kernel_ubuntu
-
-build_kernel_ubuntu_20_04:
-  image: ubuntu:20.04
-  extends: .build_kernel_ubuntu
-
 build_kernel_ubuntu_22_04:
   image: ubuntu:22.04
   extends: .build_kernel_ubuntu
 
-build_kernel_ubuntu_18_04_debug:
-  variables:
-    MODE: "all"
-  image: ubuntu:18.04
+build_kernel_ubuntu_24_04:
+  image: ubuntu:24.04
   extends: .build_kernel_ubuntu
 
-build_kernel_ubuntu_20_04_debug:
-  variables:
-    MODE: "all"
-  image: ubuntu:20.04
+build_kernel_ubuntu_26_04:
+  image: ubuntu:26.04
   extends: .build_kernel_ubuntu
 
 build_kernel_ubuntu_22_04_debug:
@@ -190,18 +177,36 @@ build_kernel_ubuntu_22_04_debug:
   image: ubuntu:22.04
   extends: .build_kernel_ubuntu
 
+build_kernel_ubuntu_24_04_debug:
+  variables:
+    MODE: "all"
+  image: ubuntu:24.04
+  extends: .build_kernel_ubuntu
+
+build_kernel_ubuntu_26_04_debug:
+  variables:
+    MODE: "all"
+  image: ubuntu:26.04
+  extends: .build_kernel_ubuntu
+
 build_kernel_arm32v7_debug:
   stage: build_kernel
   variables:
     MODE: "all"
-  image: arm32v7/ubuntu:18.04
+  image:
+    name: ubuntu:22.04
+    docker:
+      platform: linux/arm
   extends: .build_kernel_ubuntu
 
 build_kernel_arm64v8_debug:
   stage: build_kernel
   variables:
     MODE: "all"
-  image: arm64v8/ubuntu:18.04
+  image:
+    name: ubuntu:22.04
+    docker:
+      platform: linux/arm64
   extends: .build_kernel_ubuntu
 
 .build_kernel_fedora:
@@ -230,14 +235,34 @@ build_kernel_rockylinux_8_debug:
     MODE: "all"
   extends: .build_kernel_fedora
 
-build_kernel_fedora_36:
-  image: fedora:36
+build_kernel_rockylinux_9:
+  image: rockylinux:9
   extends: .build_kernel_fedora
 
-build_kernel_fedora_36_debug:
+build_kernel_rockylinux_9_debug:
+  image: rockylinux:9
   variables:
     MODE: "all"
-  image: fedora:36
+  extends: .build_kernel_fedora
+
+build_kernel_rockylinux_10:
+  image: rockylinux/rockylinux:10
+  extends: .build_kernel_fedora
+
+build_kernel_rockylinux_10_debug:
+  image: rockylinux/rockylinux:10
+  variables:
+    MODE: "all"
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_44:
+  image: fedora:44
+  extends: .build_kernel_fedora
+
+build_kernel_fedora_44_debug:
+  variables:
+    MODE: "all"
+  image: fedora:44
   extends: .build_kernel_fedora
 
 .build_tapasco:
@@ -261,7 +286,17 @@ build_kernel_fedora_36_debug:
   variables:
     PACKAGE_TYPE: "RPM"
   before_script:
-    - dnf -y update libarchive
+    - dnf -y install kernel-devel make gcc gcc-c++ elfutils-libelf-devel cmake ncurses-devel python3 libatomic git rpm-build curl protobuf-compiler protobuf
+  artifacts:
+    paths:
+      - build/tapasco-*-Linux.rpm
+  extends: .build_tapasco
+
+.build_tapasco_rockylinux:
+  variables:
+    PACKAGE_TYPE: "RPM"
+  before_script:
+    - dnf -y install epel-release && dnf config-manager --set-enable crb
     - dnf -y install kernel-devel make gcc gcc-c++ elfutils-libelf-devel cmake ncurses-devel python3 libatomic git rpm-build curl protobuf-compiler protobuf
   artifacts:
     paths:
@@ -275,18 +310,41 @@ build_tapasco_rockylinux_8:
 build_tapasco_rockylinux_8_debug:
   variables:
     MODE: "debug"
-  image: rockylinux:8
+  extends: build_tapasco_rockylinux_8
+
+build_tapasco_rockylinux_9:
+  image: rockylinux:9
+  before_script:
+    - dnf -y install epel-release && dnf config-manager --set-enable crb
+    - dnf -y install --allowerasing kernel-devel make gcc gcc-c++ elfutils-libelf-devel cmake ncurses-devel python3 libatomic git rpm-build curl protobuf-compiler protobuf
   extends: .build_tapasco_fedora
 
-build_tapasco_fedora_36:
-  image: fedora:36
-  extends: .build_tapasco_fedora
-
-build_tapasco_fedora_36_debug:
+build_tapasco_rockylinux_9_debug:
   variables:
     MODE: "debug"
-  image: fedora:36
+  extends: build_tapasco_rockylinux_9
+
+build_tapasco_rockylinux_10:
+  image: rockylinux/rockylinux:10
+  before_script:
+    - dnf -y install epel-release && dnf config-manager --set-enable crb
+    - dnf -y install kernel-devel make gcc gcc-c++ elfutils-libelf-devel cmake ncurses-devel python3 libatomic git rpm-build curl protobuf-compiler protobuf
   extends: .build_tapasco_fedora
+
+build_tapasco_rockylinux_10_debug:
+  variables:
+    MODE: "debug"
+  image: rockylinux/rockylinux:10
+  extends: build_tapasco_rockylinux_10
+
+build_tapasco_fedora_44:
+  image: fedora:44
+  extends: .build_tapasco_fedora
+
+build_tapasco_fedora_44_debug:
+  variables:
+    MODE: "debug"
+  extends: build_tapasco_fedora_44
 
 .build_tapasco_ubuntu:
   variables:
@@ -298,50 +356,32 @@ build_tapasco_fedora_36_debug:
       - build/tapasco-*-Linux.deb
   extends: .build_tapasco
 
-build_tapasco_ubuntu_18_04:
-  image: ubuntu:18.04
-  extends: .build_tapasco_ubuntu
-
-build_tapasco_ubuntu_20_04:
-  image: ubuntu:20.04
-  extends: .build_tapasco_ubuntu
-
 build_tapasco_ubuntu_22_04:
   image: ubuntu:22.04
   extends: .build_tapasco_ubuntu
 
-build_tapasco_ubuntu_16_04_cross:
+build_tapasco_ubuntu_24_04:
+  image: ubuntu:24.04
+  extends: .build_tapasco_ubuntu
+
+build_tapasco_ubuntu_26_04:
+  image: ubuntu:26.04
+  extends: .build_tapasco_ubuntu
+
+build_tapasco_ubuntu_22_04_cross:
   variables:
     TARGET: "zynq"
-  image: ubuntu:xenial
+  image: ubuntu:22.04
   before_script:
-    - apt-get -y update && apt-get -y install wget unzip build-essential linux-headers-generic python3 cmake curl libelf-dev libncurses-dev git gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
-    - wget https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip
-    - unzip -o protoc-22.3-linux-x86_64.zip -d /usr/local bin/protoc
-    - unzip -o protoc-22.3-linux-x86_64.zip -d /usr/local 'include/*'
+    - apt-get -y update && apt-get -y install wget unzip build-essential linux-headers-generic python3 cmake curl libelf-dev libncurses-dev git gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf protobuf-compiler
   extends: .build_tapasco_ubuntu
 
-build_tapasco_ubuntu_16_04_clang:
+build_tapasco_ubuntu_22_04_clang:
   variables:
     TARGET: "clang"
-  image: ubuntu:xenial
+  image: ubuntu:22.04
   before_script:
-    - apt-get -y update && apt-get -y install wget unzip build-essential linux-headers-generic python3 cmake curl libelf-dev libncurses-dev git clang
-    - wget https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip
-    - unzip -o protoc-22.3-linux-x86_64.zip -d /usr/local bin/protoc
-    - unzip -o protoc-22.3-linux-x86_64.zip -d /usr/local 'include/*'
-  extends: .build_tapasco_ubuntu
-
-build_tapasco_ubuntu_18_04_debug:
-  variables:
-    MODE: "debug"
-  image: ubuntu:18.04
-  extends: .build_tapasco_ubuntu
-
-build_tapasco_ubuntu_20_04_debug:
-  variables:
-    MODE: "debug"
-  image: ubuntu:20.04
+    - apt-get -y update && apt-get -y install wget unzip build-essential linux-headers-generic python3 cmake curl libelf-dev libncurses-dev git clang protobuf-compiler
   extends: .build_tapasco_ubuntu
 
 build_tapasco_ubuntu_22_04_debug:
@@ -350,34 +390,45 @@ build_tapasco_ubuntu_22_04_debug:
   image: ubuntu:22.04
   extends: .build_tapasco_ubuntu
 
-build_tapasco_ubuntu_16_04_cross_debug:
+build_tapasco_ubuntu_24_04_debug:
+  variables:
+    MODE: "debug"
+  image: ubuntu:24.04
+  extends: .build_tapasco_ubuntu
+
+build_tapasco_ubuntu_26_04_debug:
+  variables:
+    MODE: "debug"
+  image: ubuntu:26.04
+  extends: .build_tapasco_ubuntu
+
+build_tapasco_ubuntu_22_04_cross_debug:
   variables:
     MODE: "debug"
     TARGET: "zynq"
-  image: ubuntu:xenial
+  image: ubuntu:22.04
   before_script:
-    - apt-get -y update && apt-get -y install wget unzip build-essential linux-headers-generic python3 cmake curl libelf-dev libncurses-dev git rpm gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
-    - wget https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip
-    - unzip -o protoc-22.3-linux-x86_64.zip -d /usr/local bin/protoc
-    - unzip -o protoc-22.3-linux-x86_64.zip -d /usr/local 'include/*'
+    - apt-get -y update && apt-get -y install wget unzip build-essential linux-headers-generic python3 cmake curl libelf-dev libncurses-dev git rpm gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf protobuf-compiler
   extends: .build_tapasco_ubuntu
 
 tapasco_compose_ubuntu:
   stage: build_hw
   retry: 2
   variables:
-    VIVADO_VERSION: "2019.1"
-    XILINX_VIVADO: "/opt/cad/xilinx/vivado/Vivado/${VIVADO_VERSION}"
+    VIVADO_VERSION: "2023.1"
+    XILINX_VIVADO: "/opt/cad/xilinx/vitis/Vivado/${VIVADO_VERSION}"
     XILINXD_LICENSE_FILE: "/opt/cad/keys/xilinx"
+    LD_PRELOAD: "/usr/lib/x86_64-linux-gnu/libudev.so.1"
   tags:
     - CAD
-  image: ubuntu:18.04
+  image: ubuntu:22.04
   dependencies:
-    - build_scala_tapasco_ubuntu_18_04
+    - build_scala_tapasco_ubuntu_22_04
   script:
     - source $XILINX_VIVADO/settings64.sh
     - apt-get -y update
     - DEBIAN_FRONTEND=noninteractive apt-get -y install libtinfo5 build-essential tzdata
+    - apt install -y locales && locale-gen en_US.UTF-8 && update-locale LANG=en_US.UTF-8 && export LC_ALL=en_US.UTF-8
     - apt -y install ./toolflow/scala/build/distributions/tapasco_2025-12_amd64.deb
     - /opt/tapasco/tapasco-init-toolflow.sh
     - source tapasco-setup-toolflow.sh

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We welcome contributions from anyone interested in this field, check the [contri
 Supported FPGA devices
 ----------------------
 
-* Zynq-based: PYNQ-Z1, ZC706, ZedBoard, Ultra96V2, ZCU102
+* Zynq-based: PYNQ-Z1, ZC706, ZedBoard, Ultra96V2, ZCU102, ZCU111
 * PCIe cards: VC709, NetFPGA-SUME, VCU108, VCU118, VCU1525, Alveo U50, Alveo U250, Alveo U280, BittWare XUP-VVH, PRO DESIGN HAWK, VCK5000
 
 
@@ -34,9 +34,8 @@ System Requirements
 TaPaSCo is known to work in this environment:
 
 *   Intel x86_64 arch
-*   Linux kernel 4.4+
-*   CentOS 8, Fedora 30+, Ubuntu 16.04+
-*   Fedora 24/25 does not support debug mode due to GCC bug
+*   Linux kernel 4.18+
+*   RockyLinux 8+, Fedora 42+, Ubuntu 22.04+
 *   Bash Shell 4.2.x+
 
 Other setups likely work as well, but are untested.
@@ -46,11 +45,11 @@ Prerequisites for Toolflow
 To use TaPaSCo, you'll need working installations of
 
 *   Vivado Design Suite 2017.4 or newer
-*   Java SDK 8 - 11
+*   Java SDK 17+
 *   git
 *   python3
 *   GCC newer than 5.x.x for C++11 support
-*   *OPTIONAL:* Local Installation of gradle 5.0+, if you do not want to use the included wrapper.
+*   *OPTIONAL:* Local Installation of gradle 8.4+, if you do not want to use the included wrapper.
 
 If you want to use the High-Level Synthesis flow for generating custom IP
 cores, you will also need:
@@ -71,7 +70,7 @@ When using *Ubuntu*, ensure that the following packages are installed:
 * git
 * findutils
 * curl
-* default-jdk
+* default-jdk (openjdk-17-jdk on Ubuntu 22.04)
 
 ```
 apt-get -y install unzip git zip findutils curl default-jdk
@@ -80,11 +79,11 @@ apt-get -y install unzip git zip findutils curl default-jdk
 When using *Fedora*, ensure that the following packages are installed:
 
 * which
-* java-openjdk
+* java-xx-openjdk-devel (xx = 17/21/25 depending on Fedora version)
 * findutils
 
 ```
-dnf -y install which java-openjdk findutils
+dnf -y install which java-25-openjdk-devel findutils
 ```
 
 Prerequisites for Simulation
@@ -136,6 +135,14 @@ dnf -y install kernel-devel make gcc gcc-c++ elfutils-libelf-devel cmake python3
 *Arch*:
 ```
 pacman -S linux-headers make gcc libelf libatomic_ops cmake python3 git protobuf
+```
+
+*RockyLinux*:
+
+Code-Ready Builder (CRB) repository must be enabled in RockyLinux 9+ to install protobuf compiler:
+```
+dnf -y install epel-release && dnf config-manager --set-enable crb # RockyLinux 9+ only
+dnf -y install kernel-devel make gcc gcc-c++ elfutils-libelf-devel cmake python3 libatomic git rpm-build protobuf-compiler
 ```
 
 *Rust*:

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -17,7 +17,7 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(TapascoInstall)
 
 set(CPACK_GENERATOR "RPM" "DEB" "TGZ" "ZIP" "STGZ" "TBZ2")

--- a/runtime/cmake/clang_toolchain.cmake
+++ b/runtime/cmake/clang_toolchain.cmake
@@ -15,7 +15,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 set(CMAKE_SYSTEM_NAME Linux)
 

--- a/runtime/cmake/zynq_cross_toolchain.cmake
+++ b/runtime/cmake/zynq_cross_toolchain.cmake
@@ -15,7 +15,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR arm)

--- a/runtime/examples/C++/arrayinit/CMakeLists.txt
+++ b/runtime/examples/C++/arrayinit/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Tapasco.cmake NO_POLICY_SCOPE)
 project(arrayinit)
 

--- a/runtime/examples/C++/arraysum/CMakeLists.txt
+++ b/runtime/examples/C++/arraysum/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Tapasco.cmake NO_POLICY_SCOPE)
 project(arraysum)
 

--- a/runtime/examples/C++/arrayupdate/CMakeLists.txt
+++ b/runtime/examples/C++/arrayupdate/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Tapasco.cmake NO_POLICY_SCOPE)
 project(arrayupdate)
 

--- a/runtime/examples/C++/bandwidth/CMakeLists.txt
+++ b/runtime/examples/C++/bandwidth/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Tapasco.cmake NO_POLICY_SCOPE)
 project(bandwidth)
 

--- a/runtime/examples/C++/job_completion/CMakeLists.txt
+++ b/runtime/examples/C++/job_completion/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Tapasco.cmake NO_POLICY_SCOPE)
 project(job_completion)
 

--- a/runtime/examples/C++/memcheck/CMakeLists.txt
+++ b/runtime/examples/C++/memcheck/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Tapasco.cmake NO_POLICY_SCOPE)
 project(memcheck)
 

--- a/runtime/examples/C++/memtest/CMakeLists.txt
+++ b/runtime/examples/C++/memtest/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Tapasco.cmake NO_POLICY_SCOPE)
 project(memtest)
 

--- a/runtime/examples/C++/svm/CMakeLists.txt
+++ b/runtime/examples/C++/svm/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Tapasco.cmake NO_POLICY_SCOPE)
 project(svm_example)
 

--- a/runtime/examples/C++/svm/svm-example.cpp
+++ b/runtime/examples/C++/svm/svm-example.cpp
@@ -209,7 +209,6 @@ int run_arraysum(tapasco::Tapasco *tapasco, tapasco::PEId arraysum_id)
 
 int run_arrayupdate(tapasco::Tapasco *tapasco, tapasco::PEId arrayupdate_id)
 {
-	int errs = 0;
 	std::cout << "Run arrayupdate using on-demand page migrations (ODPMs) ..." << std::endl;
 	for (int run = 0; run < RUNS; ++run) {
 		// Generate array for arrayupdate
@@ -230,7 +229,6 @@ int run_arrayupdate(tapasco::Tapasco *tapasco, tapasco::PEId arrayupdate_id)
 		job();
 
 		int iter_errs = check_arrayupdate(arr);
-		errs += iter_errs;
 		std::cout << "RUN " << run << " " << (iter_errs == 0 ? "OK" : "NOT OK")
 			  << std::endl;
 		delete[] arr;
@@ -258,7 +256,6 @@ int run_arrayupdate(tapasco::Tapasco *tapasco, tapasco::PEId arrayupdate_id)
 		job();
 
 		int iter_errs = check_arrayupdate(arr);
-		errs += iter_errs;
 		std::cout << "RUN " << run << " " << (iter_errs == 0 ? "OK" : "NOT OK")
 			  << std::endl;
 		delete[] arr;

--- a/runtime/examples/C++/tapasco-benchmark/CMakeLists.txt
+++ b/runtime/examples/C++/tapasco-benchmark/CMakeLists.txt
@@ -39,7 +39,9 @@ add_custom_command(
          ${CMAKE_CURRENT_BINARY_DIR}/json11/json11.hpp
   COMMAND rm -rf ${CMAKE_CURRENT_BINARY_DIR}/json11
   COMMAND git clone https://github.com/dropbox/json11.git
-          ${CMAKE_CURRENT_BINARY_DIR}/json11)
+          ${CMAKE_CURRENT_BINARY_DIR}/json11
+  COMMAND git -C ${CMAKE_CURRENT_BINARY_DIR}/json11 apply
+          $(TAPASCO_HOME_RUNTIME)/examples/C++/tapasco-benchmark/json11.patch)
 
 include(GNUInstallDirs)
 

--- a/runtime/examples/C++/tapasco-benchmark/CMakeLists.txt
+++ b/runtime/examples/C++/tapasco-benchmark/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Tapasco.cmake NO_POLICY_SCOPE)
 project(tapasco-benchmark)
 

--- a/runtime/examples/C++/tapasco-benchmark/json11.patch
+++ b/runtime/examples/C++/tapasco-benchmark/json11.patch
@@ -1,0 +1,12 @@
+diff --git a/json11.cpp b/json11.cpp
+index 88024e9..32dfa36 100644
+--- a/json11.cpp
++++ b/json11.cpp
+@@ -24,6 +24,7 @@
+ #include <cmath>
+ #include <cstdlib>
+ #include <cstdio>
++#include <cstdint>
+ #include <limits>
+ 
+ namespace json11 {

--- a/runtime/examples/C/arrayinit/CMakeLists.txt
+++ b/runtime/examples/C/arrayinit/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Tapasco.cmake NO_POLICY_SCOPE)
 project(arrayinit)
 

--- a/runtime/examples/C/arraysum/CMakeLists.txt
+++ b/runtime/examples/C/arraysum/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Tapasco.cmake NO_POLICY_SCOPE)
 project(arraysum)
 

--- a/runtime/examples/C/arrayupdate/CMakeLists.txt
+++ b/runtime/examples/C/arrayupdate/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(${CMAKE_CURRENT_LIST_DIR}/../../../cmake/Tapasco.cmake NO_POLICY_SCOPE)
 project(arrayupdate)
 

--- a/runtime/examples/C/cffitest/CMakeLists.txt
+++ b/runtime/examples/C/cffitest/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.15)
 
 project(cffitest)
 

--- a/runtime/examples/CMakeLists.txt
+++ b/runtime/examples/CMakeLists.txt
@@ -17,7 +17,7 @@
 # with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include(../cmake/Tapasco.cmake NO_POLICY_SCOPE)
 project(examples)
 

--- a/runtime/examples/Rust/libtapasco_svm/CMakeLists.txt
+++ b/runtime/examples/Rust/libtapasco_svm/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(libtapasco_svm)
 
 # Add a Rust/Cargo project to CMake watching all files in the current directory because Cargo already doesn't do anything if nothing has changed.

--- a/runtime/examples/Rust/libtapasco_tests/CMakeLists.txt
+++ b/runtime/examples/Rust/libtapasco_tests/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(libtapasco_tests)
 
 # Add a Rust/Cargo project to CMake watching all files in the current directory because Cargo already doesn't do anything if nothing has changed.

--- a/runtime/examples/Rust/tapasco-debug/CMakeLists.txt
+++ b/runtime/examples/Rust/tapasco-debug/CMakeLists.txt
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 project(tapasco-debug)
 
 # Add a Rust/Cargo project to CMake watching all files in the current directory because Cargo already doesn't do anything if nothing has changed.

--- a/runtime/kernel/CMakeLists.txt
+++ b/runtime/kernel/CMakeLists.txt
@@ -17,7 +17,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 # 
 
-cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 include($ENV{TAPASCO_HOME_RUNTIME}/cmake/Tapasco.cmake NO_POLICY_SCOPE)
 project(tlkm VERSION 1.0 LANGUAGES C)
 

--- a/runtime/kernel/common/eventfd_compat.h
+++ b/runtime/kernel/common/eventfd_compat.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2014-2026 Embedded Systems and Applications, TU Darmstadt.
+ *
+ * This file is part of TaPaSCo
+ * (see https://github.com/esa-tu-darmstadt/tapasco).
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef EVENTFD_COMPAT_H_
+#define EVENTFD_COMPAT_H_
+
+#include <linux/eventfd.h>
+#include <linux/version.h>
+
+#ifndef RHEL_RELEASE_CODE
+#define RHEL_RELEASE_CODE 0
+#endif
+#ifndef RHEL_RELEASE_VERSION
+#define RHEL_RELEASE_VERSION(m, n) 1
+#endif
+
+static inline void compat_eventfd_signal(struct eventfd_ctx *efd, int n)
+{
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5)
+	int i;
+	for (i = 0; i < n; ++i)
+		eventfd_signal(efd);
+#else
+	eventfd_signal(efd, n);
+#endif
+}
+
+#endif

--- a/runtime/kernel/pcie/pcie_irq.c
+++ b/runtime/kernel/pcie/pcie_irq.c
@@ -29,6 +29,7 @@
 #include "pcie/pcie_irq.h"
 #include "pcie/pcie_device.h"
 #include "pcie/pcie_qdma.h"
+#include "common/eventfd_compat.h"
 
 int pcie_irqs_init(struct tlkm_device *dev, struct list_head *interrupts)
 {
@@ -65,12 +66,7 @@ irqreturn_t intr_handler_platform(int irq, void *data)
 	struct tlkm_irq_mapping *mapping = (struct tlkm_irq_mapping *)data;
 	struct tlkm_pcie_device *dev = mapping->dev->private_data;
 	if (mapping->eventfd != 0) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
-		eventfd_signal(mapping->eventfd, 1);
-#else
-		// Linux commit 3652117 removes argument from eventfd_signal
-		eventfd_signal(mapping->eventfd);
-#endif
+		compat_eventfd_signal(mapping->eventfd, 1);
 	}
 	dev->ack_register[0] = mapping->irq_no;
 	return IRQ_HANDLED;

--- a/runtime/kernel/pcie/pcie_irq_aws.c
+++ b/runtime/kernel/pcie/pcie_irq_aws.c
@@ -28,6 +28,7 @@
 #include "pcie/pcie.h"
 #include "pcie/pcie_irq_aws.h"
 #include "pcie/pcie_device.h"
+#include "common/eventfd_compat.h"
 
 #define IRQS_PER_CONTROLLER 32
 #define NUM_DIRECT_IRQS 4
@@ -110,12 +111,7 @@ irqreturn_t aws_irq_handler(int irq, void *data)
 				}
 			}
 			if (m_start->irq_no == slot_shifted) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
-				eventfd_signal(m_start->eventfd, 1);
-#else
-				// Linux commit 3652117 removes argument from eventfd_signal
-				eventfd_signal(m_start->eventfd);
-#endif
+				compat_eventfd_signal(m_start->eventfd, 1);
 			} else {
 				// Got interrupt for unregistered interrupt
 				LOG(TLKM_LF_IRQ,

--- a/runtime/kernel/pcie/pcie_qdma.c
+++ b/runtime/kernel/pcie/pcie_qdma.c
@@ -25,6 +25,7 @@
 #include "tlkm_logging.h"
 #include "tlkm_perfc.h"
 #include "pcie/pcie_device.h"
+#include "common/eventfd_compat.h"
 
 // register offsets of QDMA core
 #define QDMA_TRQ_SEL_FMAP	0x400UL
@@ -202,12 +203,7 @@ irqreturn_t qdma_intr_handler_read(int irq, void *data)
 	volatile struct qdma_trq_sel_queue_pf *intr_ack_regs;
 
 	if (mapping->eventfd != 0) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
-		eventfd_signal(mapping->eventfd, 1);
-#else
-		// Linux commit 3652117 removes argument from eventfd_signal
-		eventfd_signal(mapping->eventfd);
-#endif
+		compat_eventfd_signal(mapping->eventfd, 1);
 	}
 	intr_ack_regs = (volatile struct qdma_trq_sel_queue_pf *)pdev->ack_register_aws;
 	intr_ack_regs->qdma_dmap_sel_c2h_dsc_pidx_0 = QDMA_IRQ_ARM;
@@ -221,12 +217,7 @@ irqreturn_t qdma_intr_handler_write(int irq, void *data)
 	volatile struct qdma_trq_sel_queue_pf *intr_ack_regs;
 
 	if (mapping->eventfd != 0) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
-		eventfd_signal(mapping->eventfd, 1);
-#else
-		// Linux commit 3652117 removes argument from eventfd_signal
-		eventfd_signal(mapping->eventfd);
-#endif
+		compat_eventfd_signal(mapping->eventfd, 1);
 	}
 	intr_ack_regs = (volatile struct qdma_trq_sel_queue_pf *)pdev->ack_register_aws;
 	intr_ack_regs->qdma_dmap_sel_h2c_dsc_pidx_0 = QDMA_IRQ_ARM;
@@ -240,9 +231,6 @@ irqreturn_t qdma_intr_handler_c2h_stream(int irq, void *data)
 	struct qdma_cmpl_status cmpl_stat;
 	volatile struct qdma_trq_sel_queue_pf *intr_ack_regs;
 	uint32_t pidx, cidx, idx_diff;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0)
-	uint32_t i;
-#endif
 
 	cmpl_stat = *((struct qdma_cmpl_status *)&pdev->cmpt_ring[QDMA_CMPT_RING_SZ - 1]);
 	pidx = cmpl_stat.pidx;
@@ -250,13 +238,7 @@ irqreturn_t qdma_intr_handler_c2h_stream(int irq, void *data)
 	idx_diff = (pidx < cidx) ? ((pidx + QDMA_CMPT_RING_SZ - 1) - cidx) : (pidx - cidx);
 
 	if (mapping->eventfd != 0) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
-		eventfd_signal(mapping->eventfd, idx_diff);
-#else
-		// Linux commit 3652117 removes argument from eventfd_signal
-		for (i = 0; i < idx_diff; ++i)
-			eventfd_signal(mapping->eventfd);
-#endif
+		compat_eventfd_signal(mapping->eventfd, idx_diff);
 	}
 	intr_ack_regs = (volatile struct qdma_trq_sel_queue_pf *)pdev->ack_register_aws;
 	intr_ack_regs->qdma_dmap_sel_wrb_cidx_1 = QDMA_DMAP_SEL_CMPT_TRIG_USER | QDMA_DMAP_SEL_CMPT_IRQ_EN | QDMA_DMAP_SEL_CMPT_WRB_EN | pidx;
@@ -270,12 +252,7 @@ irqreturn_t qdma_intr_handler_h2c_stream(int irq, void *data)
 	volatile struct qdma_trq_sel_queue_pf *intr_ack_regs;
 
 	if (mapping->eventfd != 0) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
-		eventfd_signal(mapping->eventfd, 1);
-#else
-		// Linux commit 3652117 removes argument from eventfd_signal
-		eventfd_signal(mapping->eventfd);
-#endif
+		compat_eventfd_signal(mapping->eventfd, 1);
 	}
 	intr_ack_regs = (volatile struct qdma_trq_sel_queue_pf *)pdev->ack_register_aws;
 	intr_ack_regs->qdma_dmap_sel_h2c_dsc_pidx_1 = QDMA_IRQ_ARM;

--- a/runtime/kernel/zynq/zynq_irq.c
+++ b/runtime/kernel/zynq/zynq_irq.c
@@ -28,6 +28,7 @@
 #include "tlkm_logging.h"
 #include "tlkm_slots.h"
 #include "zynq_irq.h"
+#include "common/eventfd_compat.h"
 
 #define IRQS_PER_CONTROLLER 32
 
@@ -63,12 +64,7 @@ static irqreturn_t zynq_irq_handler(int irq, void *data)
 				}
 			}
 			if (m_start->irq_no == slot) {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0)
-				eventfd_signal(m_start->eventfd, 1);
-#else
-				// Linux commit 3652117 removes argument from eventfd_signal
-				eventfd_signal(m_start->eventfd);
-#endif
+				compat_eventfd_signal(m_start->eventfd, 1);
 			} else {
 				// Got interrupt for unregistered interrupt
 				LOG(TLKM_LF_IRQ,

--- a/runtime/libtapasco/CMakeLists.txt
+++ b/runtime/libtapasco/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.15)
 
 project(
   tapasco

--- a/toolflow/scala/build.gradle
+++ b/toolflow/scala/build.gradle
@@ -35,7 +35,7 @@ plugins {
     id 'scala'
     id 'application'
     // Netflix provided plug-in for OS packaging
-    id "com.netflix.nebula.ospackage" version "11.10.1"
+    id "com.netflix.nebula.ospackage" version "12.3.0"
 }
 
 repositories {

--- a/toolflow/scala/gradle/wrapper/gradle-wrapper.properties
+++ b/toolflow/scala/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/toolflow/vivado/platform/netfpga_sume/examples/programSI5324/CMakeLists.txt
+++ b/toolflow/vivado/platform/netfpga_sume/examples/programSI5324/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.15)
 project (programSI5324)
 
 find_package(TapascoTLKM REQUIRED)


### PR DESCRIPTION
This PR contains different patches to ensure compatibility of TaPaSCo with more recent operating systems. Support of older operating systems cannot be guaranteed anymore. We focus on Ubuntu 22.04+, RockyLinux 8+ and Fedora 42+.

Changes:
* Update of Gradle wrapper
* Upgrage of minimum CMake version
* Compatibility with GCC 16
* Compatibility layer for EventFD to support backported RHEL kernels
* Adjust CI pipelines